### PR TITLE
Add explicit whitespace validation to entry schemas

### DIFF
--- a/Wordfolio.Frontend/src/features/entries/components/EntryForm.tsx
+++ b/Wordfolio.Frontend/src/features/entries/components/EntryForm.tsx
@@ -75,7 +75,7 @@ const mapToOutput = (data: EntryFormData): EntryFormOutput => {
     }));
 
     return {
-        entryText: data.entryText.trim(),
+        entryText: data.entryText,
         definitions,
         translations,
     };

--- a/Wordfolio.Frontend/src/features/entries/schemas/entrySchemas.ts
+++ b/Wordfolio.Frontend/src/features/entries/schemas/entrySchemas.ts
@@ -1,10 +1,15 @@
 import { z } from "zod";
 
+const trimmed = (val: string) => val === val.trim();
+
 export const exampleSchema = z.object({
     exampleText: z
         .string()
         .min(1, "Example text is required")
-        .max(500, "Example must be at most 500 characters"),
+        .max(500, "Example must be at most 500 characters")
+        .refine(trimmed, {
+            message: "Cannot have leading or trailing whitespace",
+        }),
     source: z.enum(["Api", "Custom"]),
 });
 
@@ -12,7 +17,10 @@ export const definitionSchema = z.object({
     definitionText: z
         .string()
         .min(1, "Definition text is required")
-        .max(255, "Definition must be at most 255 characters"),
+        .max(255, "Definition must be at most 255 characters")
+        .refine(trimmed, {
+            message: "Cannot have leading or trailing whitespace",
+        }),
     source: z.enum(["Api", "Manual"]),
     examples: z.array(exampleSchema),
 });
@@ -21,7 +29,10 @@ export const translationSchema = z.object({
     translationText: z
         .string()
         .min(1, "Translation text is required")
-        .max(255, "Translation must be at most 255 characters"),
+        .max(255, "Translation must be at most 255 characters")
+        .refine(trimmed, {
+            message: "Cannot have leading or trailing whitespace",
+        }),
     source: z.enum(["Api", "Manual"]),
     examples: z.array(exampleSchema),
 });
@@ -31,7 +42,10 @@ export const entrySchema = z
         entryText: z
             .string()
             .min(1, "Entry text is required")
-            .max(255, "Entry text must be at most 255 characters"),
+            .max(255, "Entry text must be at most 255 characters")
+            .refine(trimmed, {
+                message: "Cannot have leading or trailing whitespace",
+            }),
         definitions: z.array(definitionSchema),
         translations: z.array(translationSchema),
     })
@@ -62,7 +76,10 @@ export const entryFormSchema = z
         entryText: z
             .string()
             .min(1, "Entry text is required")
-            .max(255, "Entry text must be at most 255 characters"),
+            .max(255, "Entry text must be at most 255 characters")
+            .refine(trimmed, {
+                message: "Cannot have leading or trailing whitespace",
+            }),
         definitions: z.array(definitionFormSchema),
         translations: z.array(translationFormSchema),
     })


### PR DESCRIPTION
## Summary
- Added a `trimmed` Zod refinement helper function in `entrySchemas.ts`
- Applied whitespace validation to all text fields (entry, definition, translation, example)
- Removed implicit `.trim()` call from `EntryForm.tsx` `mapToOutput` function
- Updated tests to validate the new explicit whitespace validation behavior

## Motivation
Previously, the `EntryForm` component silently trimmed user input in the `mapToOutput` function. This was not transparent to users, as they wouldn't receive any feedback if their input had leading or trailing whitespace. The new approach validates that strings are already trimmed and provides explicit error messages when validation fails.

## Changes
### Schema (`entrySchemas.ts`)
- Created a reusable `trimmed` helper that wraps Zod string schemas with a refinement
- Applied to all text fields: `exampleText`, `definitionText`, `translationText`, and `entryText` (both base and form schemas)
- Error message: "Cannot have leading or trailing whitespace"

### Component (`EntryForm.tsx`)
- Removed `.trim()` call from `data.entryText` in `mapToOutput` function
- Input is now passed through unchanged, relying on schema validation to enforce trimming requirements

### Tests (`EntryForm.test.tsx`)
- Updated test data to use valid input without whitespace
- Replaced "trims entry text in output" test with "validates entry text has no leading or trailing whitespace" test
- All 84 frontend tests passing

## Verification
- ✅ All frontend tests pass (`npm test`)
- ✅ Users now receive explicit validation feedback for whitespace issues
- ✅ No silent data modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)