### PR TITLE
Fix postgres bind mount path for Linux

### DIFF
--- a/Wordfolio.AppHost/appsettings.Development.json
+++ b/Wordfolio.AppHost/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "DatabaseOptions": {
-    "DataBindMount": "D:\\Postgres",
+    "DataBindMount": "/var/lib/postgresql/data",
     "Port": 5432
   }
 }


### PR DESCRIPTION
## Summary
- Replace Windows-style path `D:\Postgres` with Linux path `/var/lib/postgresql/data` for the PostgreSQL container bind mount in `appsettings.Development.json`