### PR TITLE
Rename fixed-ports config to fixed-frontend-port after removing API port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,4 +244,5 @@ Vitest + React Testing Library. Tests in `Wordfolio.Frontend/tests/`, mirroring 
 @Wordfolio.Api/Wordfolio.Api.DataAccess/AGENTS.md
 @Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/AGENTS.md
 @Wordfolio.Api/Wordfolio.Api.Tests/AGENTS.md
+@Wordfolio.AppHost/AGENTS.md
 @Wordfolio.Frontend/AGENTS.md

--- a/Wordfolio.AppHost/AGENTS.md
+++ b/Wordfolio.AppHost/AGENTS.md
@@ -1,0 +1,36 @@
+# AppHost Design Rules
+
+**Scope:** `Wordfolio.AppHost` project only.
+
+These rules govern the .NET Aspire orchestration host: launch profiles, port configuration, and resource wiring. They complement but do not replace the project-wide conventions in the root `AGENTS.md`.
+
+---
+
+## Launch Profiles
+
+Two launch profiles are defined in `Properties/launchSettings.json`:
+
+| Profile | Behavior |
+|---------|----------|
+| `https` | Default profile. Aspire assigns random ports to the API and frontend on each run. |
+| `https-fixed-frontend` | Sets `WORDFOLIO_FIXED_FRONTEND_PORT=true`, which pins the frontend to the port specified in `FixedFrontendPortOptions.FrontendPort` (defined in `appsettings.Development.json`). The API still gets a random port. |
+
+Use the fixed-frontend profile when external tools (e.g. a browser extension or mobile app) need a stable frontend URL:
+
+```bash
+dotnet run --launch-profile https-fixed-frontend
+```
+
+## Port Configuration Rules
+
+- The frontend port is only fixed when `WORDFOLIO_FIXED_FRONTEND_PORT` is `true`. The default profile always uses random ports.
+- The API port is never fixed. External access goes through the frontend; the API is not exposed directly.
+- The fixed frontend port value is configured in `appsettings.Development.json` under the `FixedFrontendPortOptions` section and bound to the `FixedFrontendPortOptions` record in `Configuration.cs`.
+- The database port is configured in `appsettings.Development.json` under the `DatabaseOptions` section and is always fixed (not affected by the launch profile).
+
+## Resource Wiring Rules
+
+- Resources are wired in dependency order: PostgreSQL, then migration runner, then API, then frontend.
+- The migration runner runs to completion (`WaitForCompletion`) before the API starts.
+- The frontend references the API (`WithReference`), which injects the API's URL automatically via Aspire service discovery.
+- Secrets (database credentials, API keys) are declared as parameters, not hardcoded.

--- a/Wordfolio.AppHost/AppHost.cs
+++ b/Wordfolio.AppHost/AppHost.cs
@@ -14,12 +14,12 @@ var databaseOptions =
         .GetRequiredSection(Configuration.DatabaseOptionsSection)
         .Get<DatabaseOptions>()!;
 
-var useFixedPorts = builder.Configuration.GetValue<bool>("WORDFOLIO_FIXED_PORTS");
+var useFixedFrontendPort = builder.Configuration.GetValue<bool>("WORDFOLIO_FIXED_FRONTEND_PORT");
 
-var fixedPortOptions =
+var fixedFrontendPortOptions =
     builder.Configuration
-        .GetRequiredSection(Configuration.FixedPortOptionsSection)
-        .Get<FixedPortOptions>()!;
+        .GetRequiredSection(Configuration.FixedFrontendPortOptionsSection)
+        .Get<FixedFrontendPortOptions>()!;
 
 var postgres =
     builder.AddPostgres("postgres", postgresUsername, postgresPassword)
@@ -34,21 +34,22 @@ var migrationService = builder.AddProject<Projects.Wordfolio_MigrationRunner>("m
     .WaitFor(postgresDatabase);
 
 var api = builder.AddProject<Projects.Wordfolio_Api>("apiservice")
-    .WithHttpEndpoint(port: useFixedPorts ? fixedPortOptions.ApiPort : null)
     .WithReference(postgresDatabase)
     .WaitForCompletion(migrationService)
     .WithHttpHealthCheck("/health")
-    .WithExternalHttpEndpoints()
     .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Development")
     .WithEnvironment("GroqApi__ApiKey", groqApiKey);
 
 var frontend = builder.AddViteApp("frontend", "../Wordfolio.Frontend")
     .WithReference(api)
     .WithEnvironment("BROWSER", "none")
-    .WithExternalHttpEndpoints()
     .PublishAsDockerFile();
 
-if (useFixedPorts)
-    frontend.WithEndpoint("http", endpoint => endpoint.Port = fixedPortOptions.FrontendPort);
+if (useFixedFrontendPort)
+    frontend.WithEndpoint("http", endpoint =>
+    {
+        endpoint.Port = fixedFrontendPortOptions.FrontendPort;
+        endpoint.TargetHost = "0.0.0.0";
+    });
 
 builder.Build().Run();

--- a/Wordfolio.AppHost/Configuration.cs
+++ b/Wordfolio.AppHost/Configuration.cs
@@ -3,9 +3,9 @@
 public class Configuration
 {
     public const string DatabaseOptionsSection = "DatabaseOptions";
-    public const string FixedPortOptionsSection = "FixedPortOptions";
+    public const string FixedFrontendPortOptionsSection = "FixedFrontendPortOptions";
 }
 
 public record DatabaseOptions(string DataBindMount, int Port);
 
-public record FixedPortOptions(int ApiPort, int FrontendPort);
+public record FixedFrontendPortOptions(int FrontendPort);

--- a/Wordfolio.AppHost/Properties/launchSettings.json
+++ b/Wordfolio.AppHost/Properties/launchSettings.json
@@ -11,7 +11,7 @@
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22272"
       }
     },
-    "https-fixed": {
+    "https-fixed-frontend": {
       "commandName": "Project",
       "applicationUrl": "https://localhost:17083;http://localhost:15173",
       "environmentVariables": {
@@ -19,7 +19,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
         "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22272",
-        "WORDFOLIO_FIXED_PORTS": "true"
+        "WORDFOLIO_FIXED_FRONTEND_PORT": "true"
       }
     }
   }

--- a/Wordfolio.AppHost/appsettings.Development.json
+++ b/Wordfolio.AppHost/appsettings.Development.json
@@ -9,8 +9,7 @@
     "DataBindMount": "/var/lib/postgresql/data",
     "Port": 5432
   },
-  "FixedPortOptions": {
-    "ApiPort": 5470,
+  "FixedFrontendPortOptions": {
     "FrontendPort": 5173
   }
 }


### PR DESCRIPTION
The https-fixed profile now only fixes the frontend port, so rename the launch profile, env var, config section, and record to reflect this.