### PR TITLE
Fix cascade delete for collections with vocabularies

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/DeleteCollectionTests.fs
@@ -43,6 +43,101 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
         }
 
     [<Fact>]
+    member _.``deleteCollectionAsync cascades to vocabularies and entries``() =
+        task {
+            do! fixture.ResetDatabaseAsync()
+
+            let createdAt =
+                DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
+            let user = Entities.makeUser 103
+
+            let collectionToDelete =
+                Entities.makeCollection user "Collection to delete" None createdAt None false
+
+            let untouchedCollection =
+                Entities.makeCollection user "Untouched Collection" None createdAt None false
+
+            let vocabulary =
+                Entities.makeVocabulary collectionToDelete "Vocabulary to delete" None createdAt None false
+
+            let untouchedVocabulary =
+                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None createdAt None false
+
+            let entry =
+                Entities.makeEntry vocabulary "word" createdAt None
+
+            let untouchedEntry =
+                Entities.makeEntry untouchedVocabulary "untouched word" createdAt None
+
+            do!
+                fixture.Seeder
+                |> Seeder.addUsers [ user ]
+                |> Seeder.addCollections [ collectionToDelete; untouchedCollection ]
+                |> Seeder.addVocabularies [ vocabulary; untouchedVocabulary ]
+                |> Seeder.addEntries [ entry; untouchedEntry ]
+                |> Seeder.saveChangesAsync
+
+            let! affectedRows =
+                Collections.deleteCollectionAsync collectionToDelete.Id
+                |> fixture.WithConnectionAsync
+
+            Assert.Equal(1, affectedRows)
+
+            let! actualCollections =
+                fixture.Seeder
+                |> Seeder.getAllCollectionsAsync
+
+            let actualCollection =
+                Assert.Single(actualCollections)
+
+            let expectedCollection: Collection =
+                { Id = untouchedCollection.Id
+                  UserId = 103
+                  Name = "Untouched Collection"
+                  Description = None
+                  CreatedAt = createdAt
+                  UpdatedAt = None
+                  IsSystem = false }
+
+            Assert.Equal(expectedCollection, actualCollection)
+
+            let! actualVocabularies =
+                fixture.Seeder
+                |> Seeder.getAllVocabulariesAsync
+
+            let actualVocabulary =
+                Assert.Single(actualVocabularies)
+
+            let expectedVocabulary: Vocabulary =
+                { Id = untouchedVocabulary.Id
+                  CollectionId = untouchedCollection.Id
+                  Name = "Untouched Vocabulary"
+                  Description = None
+                  CreatedAt = createdAt
+                  UpdatedAt = None
+                  IsDefault = false }
+
+            Assert.Equal(expectedVocabulary, actualVocabulary)
+
+            let! actualEntries =
+                fixture.Seeder
+                |> Seeder.getAllEntriesAsync
+
+            let actualEntry =
+                Assert.Single(actualEntries)
+
+            let expectedEntry: Entry =
+                { Id = untouchedEntry.Id
+                  VocabularyId = untouchedVocabulary.Id
+                  EntryText = "untouched word"
+                  CreatedAt = createdAt
+                  UpdatedAt = None }
+
+            Assert.Equal(expectedEntry, actualEntry)
+        }
+
+    [<Fact>]
     member _.``deleteCollectionAsync returns 0 when collection does not exist``() =
         task {
             do! fixture.ResetDatabaseAsync()

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/20260321001_AddCascadeDeleteToVocabulariesCollectionForeignKey.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/20260321001_AddCascadeDeleteToVocabulariesCollectionForeignKey.fs
@@ -1,0 +1,44 @@
+namespace Wordfolio.Api.Migrations
+
+open FluentMigrator
+
+open Constants
+
+[<Migration(20260321001L)>]
+type AddCascadeDeleteToVocabulariesCollectionForeignKey() =
+    inherit Migration()
+
+    override this.Up() =
+        base.Delete
+            .ForeignKey("FK_Vocabularies_CollectionId_Collections_Id")
+            .OnTable(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_Vocabularies_CollectionId_Collections_Id")
+            .FromTable(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(VocabulariesTable.CollectionIdColumn)
+            .ToTable(CollectionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn(CollectionsTable.IdColumn)
+            .OnDelete(System.Data.Rule.Cascade)
+        |> ignore
+
+    override this.Down() =
+        base.Delete
+            .ForeignKey("FK_Vocabularies_CollectionId_Collections_Id")
+            .OnTable(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_Vocabularies_CollectionId_Collections_Id")
+            .FromTable(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(VocabulariesTable.CollectionIdColumn)
+            .ToTable(CollectionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn(CollectionsTable.IdColumn)
+        |> ignore

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="20251225004_CreateExamplesTable.fs" />
     <Compile Include="20251225005_AddExamplesCheckConstraint.fs" />
     <Compile Include="20260110001_AddSystemCollectionsAndDefaultVocabularies.fs" />
+    <Compile Include="20260321001_AddCascadeDeleteToVocabulariesCollectionForeignKey.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
@@ -70,6 +70,109 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
         }
 
     [<Fact>]
+    member _.``DELETE deletes collection with vocabularies and entries``() : Task =
+        task {
+            do! fixture.ResetDatabaseAsync()
+
+            use factory =
+                new WebApplicationFactory(fixture)
+
+            let! identityUser, wordfolioUser = factory.CreateUserAsync(112, "user@example.com", "P@ssw0rd!")
+
+            let collection =
+                Entities.makeCollection wordfolioUser "Collection with content" None DateTimeOffset.UtcNow None false
+
+            let untouchedCollection =
+                Entities.makeCollection
+                    wordfolioUser
+                    "Untouched Collection"
+                    (Some "Untouched Description")
+                    DateTimeOffset.UtcNow
+                    None
+                    false
+
+            let vocabulary =
+                Entities.makeVocabulary collection "Vocabulary" None DateTimeOffset.UtcNow None false
+
+            let untouchedVocabulary =
+                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None DateTimeOffset.UtcNow None false
+
+            let entry =
+                Entities.makeEntry vocabulary "word" DateTimeOffset.UtcNow None
+
+            let untouchedEntry =
+                Entities.makeEntry untouchedVocabulary "untouched word" DateTimeOffset.UtcNow None
+
+            do!
+                fixture.WordfolioSeeder
+                |> Seeder.addUsers [ wordfolioUser ]
+                |> Seeder.addCollections [ collection; untouchedCollection ]
+                |> Seeder.addVocabularies [ vocabulary; untouchedVocabulary ]
+                |> Seeder.addEntries [ entry; untouchedEntry ]
+                |> Seeder.saveChangesAsync
+
+            use! client = factory.CreateAuthenticatedClientAsync(identityUser)
+
+            let! response = client.DeleteAsync(Urls.Collections.collectionById collection.Id)
+            let! body = response.Content.ReadAsStringAsync()
+
+            Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode)
+
+            let! actualCollections =
+                fixture.WordfolioSeeder
+                |> Seeder.getAllCollectionsAsync
+
+            let actualCollection =
+                Assert.Single(actualCollections)
+
+            let expectedCollection: Wordfolio.Collection =
+                { Id = untouchedCollection.Id
+                  UserId = 112
+                  Name = "Untouched Collection"
+                  Description = Some "Untouched Description"
+                  CreatedAt = actualCollection.CreatedAt
+                  UpdatedAt = actualCollection.UpdatedAt
+                  IsSystem = false }
+
+            Assert.Equal(expectedCollection, actualCollection)
+
+            let! actualVocabularies =
+                fixture.WordfolioSeeder
+                |> Seeder.getAllVocabulariesAsync
+
+            let actualVocabulary =
+                Assert.Single(actualVocabularies)
+
+            let expectedVocabulary: Wordfolio.Vocabulary =
+                { Id = untouchedVocabulary.Id
+                  CollectionId = untouchedCollection.Id
+                  Name = "Untouched Vocabulary"
+                  Description = None
+                  CreatedAt = actualVocabulary.CreatedAt
+                  UpdatedAt = actualVocabulary.UpdatedAt
+                  IsDefault = false }
+
+            Assert.Equal(expectedVocabulary, actualVocabulary)
+
+            let! actualEntries =
+                fixture.WordfolioSeeder
+                |> Seeder.getAllEntriesAsync
+
+            let actualEntry =
+                Assert.Single(actualEntries)
+
+            let expectedEntry: Wordfolio.Entry =
+                { Id = untouchedEntry.Id
+                  VocabularyId = untouchedVocabulary.Id
+                  EntryText = "untouched word"
+                  CreatedAt = actualEntry.CreatedAt
+                  UpdatedAt = actualEntry.UpdatedAt }
+
+            Assert.Equal(expectedEntry, actualEntry)
+        }
+
+    [<Fact>]
     member _.``DELETE returns 404 when collection does not exist``() : Task =
         task {
             do! fixture.ResetDatabaseAsync()

--- a/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
@@ -60,7 +60,7 @@ export const CollectionDetailPage = () => {
         assertNonNullable(collection?.id);
         const confirmed = await raiseConfirmDialogAsync({
             title: "Delete Collection",
-            message: `Are you sure you want to delete "${collection.name}"?`,
+            message: `Are you sure you want to delete "${collection.name}"? This will also delete all vocabularies and entries within it.`,
             confirmLabel: "Delete",
             confirmColor: "error",
         });


### PR DESCRIPTION
Add ON DELETE CASCADE to the Vocabularies.CollectionId foreign key so that deleting a collection automatically removes its vocabularies and their entries. Update the delete confirmation dialog to warn the user about the cascade. Add data access and API integration tests to verify the cascade behaviour.