### PR TITLE
Extend design system with input adornment icon and move styles to theme

### DIFF
--- a/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
+++ b/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
@@ -4,6 +4,8 @@ import {
     Button,
     Chip,
     Divider,
+    IconButton,
+    InputAdornment,
     Link,
     MenuItem,
     TextField,
@@ -13,6 +15,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
+import Visibility from "@mui/icons-material/Visibility";
 import { DataGrid } from "@mui/x-data-grid";
 import type { GridColDef } from "@mui/x-data-grid";
 
@@ -408,6 +411,29 @@ export const DesignSystemPage = () => {
                                 label="Text Input"
                                 placeholder="Enter a name..."
                                 fullWidth
+                            />
+                            <TextField
+                                label="Input with Icon"
+                                placeholder="Enter a value..."
+                                fullWidth
+                                slotProps={{
+                                    input: {
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton edge="end">
+                                                    <Visibility />
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    },
+                                }}
+                            />
+                            <TextField
+                                label="Text Input"
+                                placeholder="Enter a name..."
+                                fullWidth
+                                error
+                                helperText="This field is required"
                             />
                             <TextField
                                 label="Textarea"

--- a/Wordfolio.Frontend/src/shared/components/PasswordField.tsx
+++ b/Wordfolio.Frontend/src/shared/components/PasswordField.tsx
@@ -22,19 +22,11 @@ export const PasswordField = (props: PasswordFieldProps) => {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 onMouseDown={(e) => e.preventDefault()}
                                 edge="end"
-                                size="small"
-                                sx={{
-                                    color: "text.placeholder",
-                                    padding: "4px",
-                                    height: "auto",
-                                    width: "auto",
-                                    borderRadius: "50%",
-                                }}
                             >
                                 {showPassword ? (
-                                    <VisibilityOff sx={{ fontSize: "14px" }} />
+                                    <VisibilityOff />
                                 ) : (
-                                    <Visibility sx={{ fontSize: "14px" }} />
+                                    <Visibility />
                                 )}
                             </IconButton>
                         </InputAdornment>

--- a/Wordfolio.Frontend/src/theme.ts
+++ b/Wordfolio.Frontend/src/theme.ts
@@ -186,6 +186,9 @@ export const theme = createTheme({
             },
         },
         MuiIconButton: {
+            defaultProps: {
+                size: "small",
+            },
             styleOverrides: {
                 root: {
                     borderRadius: 8,
@@ -488,6 +491,22 @@ export const theme = createTheme({
                     },
                     lineHeight: "12px",
                     padding: "5px 20px",
+                },
+            },
+        },
+        MuiInputAdornment: {
+            styleOverrides: {
+                root: {
+                    "& .MuiIconButton-root": {
+                        color: textPlaceholder,
+                        padding: "4px",
+                        height: "auto",
+                        width: "auto",
+                        borderRadius: "50%",
+                        "& .MuiSvgIcon-root": {
+                            fontSize: "14px",
+                        },
+                    },
                 },
             },
         },


### PR DESCRIPTION
- Add input with icon button adornment and error state field to design system page
- Add MuiInputAdornment and MuiIconButton defaultProps/styleOverrides to theme so adornment icon buttons are styled without per-component sx overrides
- Remove sx overrides from PasswordField, relying on theme instead