### PR TITLE
Default Move Entry dialog to Drafts

### DIFF
--- a/Wordfolio.Frontend/src/shared/components/MoveEntryDialog.tsx
+++ b/Wordfolio.Frontend/src/shared/components/MoveEntryDialog.tsx
@@ -43,11 +43,21 @@ export const MoveEntryDialog = ({
         refetch: refetchHierarchy,
     } = useCollectionsHierarchyQuery();
 
+    const defaultTargetVocabularyId = useMemo(() => {
+        if (!hierarchy) {
+            return undefined;
+        }
+
+        return hierarchy.defaultVocabulary?.id !== currentVocabularyId
+            ? draftsValue
+            : undefined;
+    }, [currentVocabularyId, hierarchy]);
+
     useEffect(() => {
         if (isOpen) {
-            setSelectedVocabularyId(undefined);
+            setSelectedVocabularyId(defaultTargetVocabularyId);
         }
-    }, [currentVocabularyId, isOpen]);
+    }, [currentVocabularyId, defaultTargetVocabularyId, isOpen]);
 
     const hasTargets = useMemo(() => {
         if (!hierarchy) {

--- a/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { MoveEntryDialog } from "../../../src/shared/components/MoveEntryDialog";
+import { draftsValue } from "../../../src/shared/components/VocabularySelector";
+import type { CollectionsHierarchy } from "../../../src/shared/api/types/collections";
+
+const useCollectionsHierarchyQueryMock = vi.fn();
+
+vi.mock("../../../src/shared/api/queries/collections", () => ({
+    useCollectionsHierarchyQuery: () => useCollectionsHierarchyQueryMock(),
+}));
+
+const createHierarchy = (
+    overrides?: Partial<CollectionsHierarchy>
+): CollectionsHierarchy => ({
+    collections: [
+        {
+            id: 1,
+            name: "English Collection",
+            description: null,
+            createdAt: new Date(),
+            updatedAt: null,
+            vocabularies: [
+                {
+                    id: 10,
+                    name: "Idioms",
+                    description: null,
+                    entryCount: 5,
+                    createdAt: new Date(),
+                    updatedAt: null,
+                },
+            ],
+        },
+    ],
+    defaultVocabulary: {
+        id: 99,
+        name: "Drafts",
+        description: null,
+        entryCount: 3,
+        createdAt: new Date(),
+        updatedAt: null,
+    },
+    ...overrides,
+});
+
+const renderMoveEntryDialog = (currentVocabularyId: number) =>
+    render(
+        <MoveEntryDialog
+            isOpen={true}
+            currentVocabularyId={currentVocabularyId}
+            onCancel={vi.fn()}
+            onConfirm={vi.fn()}
+        />
+    );
+
+describe("MoveEntryDialog", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("pre-selects drafts when drafts is an available move target", () => {
+        useCollectionsHierarchyQueryMock.mockReturnValue({
+            data: createHierarchy(),
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+
+        renderMoveEntryDialog(10);
+
+        expect(screen.getByRole("combobox")).toHaveTextContent(
+            "Drafts — organize later"
+        );
+        expect(screen.getByRole("button", { name: "Move" })).toBeEnabled();
+    });
+
+    it("does not pre-select a target when drafts is unavailable", () => {
+        useCollectionsHierarchyQueryMock.mockReturnValue({
+            data: createHierarchy({
+                defaultVocabulary: {
+                    id: 10,
+                    name: "Drafts",
+                    description: null,
+                    entryCount: 3,
+                    createdAt: new Date(),
+                    updatedAt: null,
+                },
+            }),
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+
+        renderMoveEntryDialog(10);
+
+        expect(screen.getByRole("combobox")).not.toHaveTextContent(
+            "Drafts — organize later"
+        );
+        expect(screen.getByRole("button", { name: "Move" })).toBeDisabled();
+    });
+
+    it("submits the drafts selection as the default vocabulary target", async () => {
+        const onConfirm = vi.fn();
+
+        useCollectionsHierarchyQueryMock.mockReturnValue({
+            data: createHierarchy(),
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        });
+
+        render(
+            <MoveEntryDialog
+                isOpen={true}
+                currentVocabularyId={10}
+                onCancel={vi.fn()}
+                onConfirm={onConfirm}
+            />
+        );
+
+        screen.getByRole("button", { name: "Move" }).click();
+
+        expect(onConfirm).toHaveBeenCalledWith({
+            vocabularyId: undefined,
+            isDefault: true,
+            collectionId: null,
+        });
+        expect(useCollectionsHierarchyQueryMock).toHaveBeenCalled();
+        expect(draftsValue).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- default the Move Entry dialog target to Drafts whenever Drafts is an eligible destination
- add focused frontend coverage for the new default-selection behavior
- manually verify in the running app that the Move Entry dialog opens with Drafts pre-selected

## Validation
- cd Wordfolio.Frontend && npm run lint
- cd Wordfolio.Frontend && npm test -- --run
- cd Wordfolio.Frontend && npm run build
- Manual verification with AppHost + Playwright on a real entry detail page