### PR TITLE
Prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/Wordfolio.Frontend/src/main.tsx
+++ b/Wordfolio.Frontend/src/main.tsx
@@ -6,11 +6,14 @@ import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import { NotificationProvider } from "./shared/contexts/NotificationProvider";
 import { ConfirmDialogProvider } from "./shared/contexts/ConfirmDialogProvider";
+import { preventIosFocusAutoZoom } from "./shared/utils/iosAutoZoomFix";
 import { theme } from "./theme";
 import { routeTree } from "./routeTree.gen";
 import { LostInTranslationAtlasPage } from "./features/not-found/pages/LostInTranslationAtlasPage";
 
 import "./main.css";
+
+preventIosFocusAutoZoom();
 
 const router = createRouter({
     routeTree,

--- a/Wordfolio.Frontend/src/shared/utils/iosAutoZoomFix.ts
+++ b/Wordfolio.Frontend/src/shared/utils/iosAutoZoomFix.ts
@@ -1,0 +1,23 @@
+import { ensureNonNullable } from "./misc";
+
+export function preventIosFocusAutoZoom(): void {
+    const userAgent = window.navigator.userAgent;
+    const isIos = /iPad|iPhone|iPod/.test(userAgent);
+    const isIpadOs =
+        /Macintosh/.test(userAgent) && window.navigator.maxTouchPoints > 1;
+
+    if (!isIos && !isIpadOs) {
+        return;
+    }
+
+    const viewportMeta = ensureNonNullable(
+        document.querySelector<HTMLMetaElement>('meta[name="viewport"]')
+    );
+    const existingContent = viewportMeta.getAttribute("content") ?? "";
+    const preservedParts = existingContent
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0 && !/^maximum-scale\s*=/.test(part));
+    preservedParts.push("maximum-scale=1");
+    viewportMeta.setAttribute("content", preservedParts.join(", "));
+}


### PR DESCRIPTION
## Summary

- Add a boot-time helper (`src/shared/utils/iosAutoZoomFix.ts`) that merges `maximum-scale=1` into the viewport meta tag only on iOS and modern iPadOS, then call it from `main.tsx` before React mounts so every input in the app is covered without per-component changes.
- iOS Safari (and every iOS browser, which all share WebKit under Apple's engine restriction) auto-zooms the page when a focused control's computed font-size is below 16px. The fix is conditional because Android Chrome and desktop browsers never exhibit this behaviour, and a global `maximum-scale=1` would regress their pinch-zoom accessibility — option 2 from the design discussion preserves the iOS fix and the Android pinch-zoom simultaneously.
- iPadOS is detected via `Macintosh` UA marker + `navigator.maxTouchPoints > 1` (since iPadOS 13, Safari reports itself as desktop Safari, but macOS trackpads report `maxTouchPoints === 0` while iPads report > 0). This avoids the deprecated `navigator.platform` API and keeps the lint run at zero warnings.
- The helper parses the existing viewport `content` and strips any pre-existing `maximum-scale=` entry before appending its own, so it does not clobber unrelated viewport settings someone might add to `index.html` later (e.g. `viewport-fit=cover`).

## Test plan

- [x] `npm run lint` — zero warnings
- [x] `npm run build` — strict TypeScript + Vite build succeeds
- [x] `npm test` — all 132 existing tests pass
- [ ] iPhone Safari: focus any input on the login page, confirm the page no longer zooms in, confirm pinch-zoom gesture still works (iOS 10+ ignores `maximum-scale` for the user's pinch gesture)
- [ ] iPadOS Safari: same verification — exercises the `Macintosh` + `maxTouchPoints > 1` detection branch
- [ ] Android Chrome: focus an input, confirm no behavioural change and pinch-zoom still works (the helper returns early and leaves the viewport meta untouched)
- [ ] Desktop Chrome / Firefox: regression check only — no change expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)