### PR TITLE
Make updatedAt mandatory

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/CreateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/CreateCollectionTests.fs
@@ -48,7 +48,7 @@ type CreateCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "My Collection"
                       Description = Some "Test collection"
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsSystem = false }
 
             Assert.Equivalent(expected, actualCollection)
@@ -88,7 +88,7 @@ type CreateCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "My Collection"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsSystem = false }
 
             Assert.Equivalent(expected, actualCollection)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/CreateDefaultCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/CreateDefaultCollectionTests.fs
@@ -48,7 +48,7 @@ type CreateDefaultCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "Unsorted"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsSystem = true }
 
             Assert.Equivalent(expected, actualCollection)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/DeleteCollectionTests.fs
@@ -22,7 +22,7 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 102
 
             let collection =
-                Entities.makeCollection user "Collection to delete" None createdAt None false
+                Entities.makeCollection user "Collection to delete" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -53,22 +53,22 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 103
 
             let collectionToDelete =
-                Entities.makeCollection user "Collection to delete" None createdAt None false
+                Entities.makeCollection user "Collection to delete" None createdAt createdAt false
 
             let untouchedCollection =
-                Entities.makeCollection user "Untouched Collection" None createdAt None false
+                Entities.makeCollection user "Untouched Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionToDelete "Vocabulary to delete" None createdAt None false
+                Entities.makeVocabulary collectionToDelete "Vocabulary to delete" None createdAt createdAt false
 
             let untouchedVocabulary =
-                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None createdAt None false
+                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "word" createdAt None
+                Entities.makeEntry vocabulary "word" createdAt createdAt
 
             let untouchedEntry =
-                Entities.makeEntry untouchedVocabulary "untouched word" createdAt None
+                Entities.makeEntry untouchedVocabulary "untouched word" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -97,7 +97,7 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
                   Name = "Untouched Collection"
                   Description = None
                   CreatedAt = createdAt
-                  UpdatedAt = None
+                  UpdatedAt = createdAt
                   IsSystem = false }
 
             Assert.Equal(expectedCollection, actualCollection)
@@ -115,7 +115,7 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
                   Name = "Untouched Vocabulary"
                   Description = None
                   CreatedAt = createdAt
-                  UpdatedAt = None
+                  UpdatedAt = createdAt
                   IsDefault = false }
 
             Assert.Equal(expectedVocabulary, actualVocabulary)
@@ -132,7 +132,7 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
                   VocabularyId = untouchedVocabulary.Id
                   EntryText = "untouched word"
                   CreatedAt = createdAt
-                  UpdatedAt = None }
+                  UpdatedAt = createdAt }
 
             Assert.Equal(expectedEntry, actualEntry)
         }
@@ -160,7 +160,7 @@ type DeleteCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetCollectionByIdTests.fs
@@ -22,7 +22,7 @@ type GetCollectionByIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "My Collection" (Some "Test collection") createdAt None false
+                Entities.makeCollection user "My Collection" (Some "Test collection") createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -40,7 +40,7 @@ type GetCollectionByIdTests(fixture: WordfolioTestFixture) =
                       Name = "My Collection"
                       Description = Some "Test collection"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -68,7 +68,7 @@ type GetCollectionByIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetCollectionsByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetCollectionsByUserIdTests.fs
@@ -23,13 +23,13 @@ type GetCollectionsByUserIdTests(fixture: WordfolioTestFixture) =
             let user2 = Entities.makeUser 101
 
             let collection1 =
-                Entities.makeCollection user1 "Collection 1" None createdAt None false
+                Entities.makeCollection user1 "Collection 1" None createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection user1 "Collection 2" None createdAt None false
+                Entities.makeCollection user1 "Collection 2" None createdAt createdAt false
 
             let _ =
-                Entities.makeCollection user2 "Collection 3" None createdAt None false
+                Entities.makeCollection user2 "Collection 3" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -46,13 +46,13 @@ type GetCollectionsByUserIdTests(fixture: WordfolioTestFixture) =
                     Name = "Collection 1"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None }
+                    UpdatedAt = createdAt }
                   { Id = collection2.Id
                     UserId = user1.Id
                     Name = "Collection 2"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = createdAt } ]
 
             Assert.Equivalent(expected, actual)
         }
@@ -87,10 +87,10 @@ type GetCollectionsByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection user "Regular Collection" None createdAt None false
+                Entities.makeCollection user "Regular Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -108,7 +108,7 @@ type GetCollectionsByUserIdTests(fixture: WordfolioTestFixture) =
                     Name = "Regular Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = createdAt } ]
 
             Assert.Equal<Collections.Collection list>(expected, actual)
         }

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetDefaultCollectionByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/GetDefaultCollectionByUserIdTests.fs
@@ -23,10 +23,10 @@ type GetDefaultCollectionByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection user "Regular" None createdAt None false
+                Entities.makeCollection user "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -45,7 +45,7 @@ type GetDefaultCollectionByUserIdTests(fixture: WordfolioTestFixture) =
                       Name = "Unsorted"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -61,7 +61,7 @@ type GetDefaultCollectionByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let regularCollection =
-                Entities.makeCollection user "Regular" None createdAt None false
+                Entities.makeCollection user "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -87,10 +87,10 @@ type GetDefaultCollectionByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection1 =
-                Entities.makeCollection user "Unsorted 1" None createdAt None true
+                Entities.makeCollection user "Unsorted 1" None createdAt createdAt true
 
             let systemCollection2 =
-                Entities.makeCollection user "Unsorted 2" None createdAt None true
+                Entities.makeCollection user "Unsorted 2" None createdAt createdAt true
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/UpdateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Collections/UpdateCollectionTests.fs
@@ -25,7 +25,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 101
 
             let collection =
-                Entities.makeCollection user "Original Name" (Some "Original Description") createdAt None false
+                Entities.makeCollection user "Original Name" (Some "Original Description") createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -51,7 +51,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "Updated Name"
                       Description = Some "Updated Description"
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt
+                      UpdatedAt = updatedAt
                       IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -71,7 +71,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 104
 
             let collection =
-                Entities.makeCollection user "Collection Name" (Some "Original Description") createdAt None false
+                Entities.makeCollection user "Collection Name" (Some "Original Description") createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -97,7 +97,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "Collection Name"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt
+                      UpdatedAt = updatedAt
                       IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -136,7 +136,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -163,7 +163,7 @@ type UpdateCollectionTests(fixture: WordfolioTestFixture) =
                       Name = "Unsorted"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsSystem = true }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetCollectionsByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetCollectionsByUserIdTests.fs
@@ -22,19 +22,19 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user = Entities.makeUser 100
 
             let collection1 =
-                Entities.makeCollection user "Collection 1" (Some "Description 1") createdAt None false
+                Entities.makeCollection user "Collection 1" (Some "Description 1") createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection user "Collection 2" None createdAt None false
+                Entities.makeCollection user "Collection 2" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection1 "Vocab 1" (Some "Vocab desc") createdAt None false
+                Entities.makeVocabulary collection1 "Vocab 1" (Some "Vocab desc") createdAt createdAt false
 
             let vocab2 =
-                Entities.makeVocabulary collection1 "Vocab 2" None createdAt None false
+                Entities.makeVocabulary collection1 "Vocab 2" None createdAt createdAt false
 
             let vocab3 =
-                Entities.makeVocabulary collection2 "Vocab 3" None createdAt None false
+                Entities.makeVocabulary collection2 "Vocab 3" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -53,32 +53,32 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "Collection 1"
                     Description = Some "Description 1"
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = vocab1.Id
                           Name = "Vocab 1"
                           Description = Some "Vocab desc"
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 }
                         { Id = vocab2.Id
                           Name = "Vocab 2"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 } ] }
                   { Id = collection2.Id
                     UserId = user.Id
                     Name = "Collection 2"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = vocab3.Id
                           Name = "Vocab 3"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 } ] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)
@@ -95,16 +95,16 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection user "Regular" None createdAt None false
+                Entities.makeCollection user "Regular" None createdAt createdAt false
 
             let _ =
-                Entities.makeVocabulary systemCollection "Default Vocab" None createdAt None false
+                Entities.makeVocabulary systemCollection "Default Vocab" None createdAt createdAt false
 
             let vocab =
-                Entities.makeVocabulary regularCollection "Regular Vocab" None createdAt None false
+                Entities.makeVocabulary regularCollection "Regular Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -121,13 +121,13 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = vocab.Id
                           Name = "Regular Vocab"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 } ] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)
@@ -144,13 +144,13 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let defaultVocab =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             let regularVocab =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -169,13 +169,13 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = regularVocab.Id
                           Name = "Regular"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 } ] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)
@@ -192,7 +192,7 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Empty Collection" None createdAt None false
+                Entities.makeCollection user "Empty Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -210,7 +210,7 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "Empty Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies = [] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)
@@ -227,25 +227,25 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection "Vocab 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocab 1" None createdAt createdAt false
 
             let vocab2 =
-                Entities.makeVocabulary collection "Vocab 2" None createdAt None false
+                Entities.makeVocabulary collection "Vocab 2" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocab1 "word1" createdAt None
+                Entities.makeEntry vocab1 "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocab1 "word2" createdAt None
+                Entities.makeEntry vocab1 "word2" createdAt createdAt
 
             let entry3 =
-                Entities.makeEntry vocab1 "word3" createdAt None
+                Entities.makeEntry vocab1 "word3" createdAt createdAt
 
             let entry4 =
-                Entities.makeEntry vocab2 "word4" createdAt None
+                Entities.makeEntry vocab2 "word4" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -265,19 +265,19 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = vocab1.Id
                           Name = "Vocab 1"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 3 }
                         { Id = vocab2.Id
                           Name = "Vocab 2"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 1 } ] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)
@@ -295,16 +295,16 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
             let user2 = Entities.makeUser 101
 
             let user1Collection =
-                Entities.makeCollection user1 "User 1 Collection" None createdAt None false
+                Entities.makeCollection user1 "User 1 Collection" None createdAt createdAt false
 
             let user2Collection =
-                Entities.makeCollection user2 "User 2 Collection" None createdAt None false
+                Entities.makeCollection user2 "User 2 Collection" None createdAt createdAt false
 
             let user1Vocab =
-                Entities.makeVocabulary user1Collection "User 1 Vocab" None createdAt None false
+                Entities.makeVocabulary user1Collection "User 1 Vocab" None createdAt createdAt false
 
             let user2Vocab =
-                Entities.makeVocabulary user2Collection "User 2 Vocab" None createdAt None false
+                Entities.makeVocabulary user2Collection "User 2 Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -323,13 +323,13 @@ type CollectionsHierarchyGetCollectionsByUserIdTests(fixture: WordfolioTestFixtu
                     Name = "User 1 Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     Vocabularies =
                       [ { Id = user1Vocab.Id
                           Name = "User 1 Vocab"
                           Description = None
                           CreatedAt = createdAt
-                          UpdatedAt = None
+                          UpdatedAt = createdAt
                           EntryCount = 0 } ] } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularies list>(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetCollectionsWithVocabularyCountByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetCollectionsWithVocabularyCountByUserIdTests.fs
@@ -22,13 +22,13 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 550
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection "Vocab 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocab 1" None createdAt createdAt false
 
             let vocab2 =
-                Entities.makeVocabulary collection "Vocab 2" None createdAt None false
+                Entities.makeVocabulary collection "Vocab 2" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -47,7 +47,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 2 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)
@@ -64,10 +64,10 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 551
 
             let regularCollection =
-                Entities.makeCollection user "Regular" None createdAt None false
+                Entities.makeCollection user "Regular" None createdAt createdAt false
 
             let systemCollection =
-                Entities.makeCollection user "System" None createdAt None true
+                Entities.makeCollection user "System" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -85,7 +85,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)
@@ -102,13 +102,13 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 552
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Regular Vocab" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default Vocab" None createdAt None true
+                Entities.makeVocabulary collection "Default Vocab" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -127,7 +127,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 1 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)
@@ -164,10 +164,10 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user2 = Entities.makeUser 555
 
             let user1Collection =
-                Entities.makeCollection user1 "User 1 Collection" None createdAt None false
+                Entities.makeCollection user1 "User 1 Collection" None createdAt createdAt false
 
             let user2Collection =
-                Entities.makeCollection user2 "User 2 Collection" None createdAt None false
+                Entities.makeCollection user2 "User 2 Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -185,7 +185,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "User 1 Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)
@@ -204,7 +204,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 556
 
             let collection =
-                Entities.makeCollection user "Empty Collection" None createdAt None false
+                Entities.makeCollection user "Empty Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -222,7 +222,7 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "Empty Collection"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)
@@ -247,16 +247,16 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 557
 
             let collectionA =
-                Entities.makeCollection user "A" None createdAt (Some updatedAt1) false
+                Entities.makeCollection user "A" None createdAt updatedAt1 false
 
             let collectionB =
-                Entities.makeCollection user "B" None createdAt (Some updatedAt2) false
+                Entities.makeCollection user "B" None createdAt updatedAt2 false
 
             let collectionC =
-                Entities.makeCollection user "C" None createdAt None false
+                Entities.makeCollection user "C" None createdAt createdAt false
 
             let collectionD =
-                Entities.makeCollection user "D" None createdAt None false
+                Entities.makeCollection user "D" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -274,28 +274,28 @@ type GetCollectionsWithVocabularyCountByUserIdTests(fixture: WordfolioTestFixtur
                     Name = "A"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAt1
+                    UpdatedAt = updatedAt1
                     VocabularyCount = 0 }
                   { Id = collectionB.Id
                     UserId = user.Id
                     Name = "B"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAt2
+                    UpdatedAt = updatedAt2
                     VocabularyCount = 0 }
                   { Id = collectionC.Id
                     UserId = user.Id
                     Name = "C"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 }
                   { Id = collectionD.Id
                     UserId = user.Id
                     Name = "D"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.CollectionWithVocabularyCount list>(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetDefaultVocabularySummaryByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetDefaultVocabularySummaryByUserIdTests.fs
@@ -22,16 +22,16 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let defaultVocab =
-                Entities.makeVocabulary systemCollection "My Words" (Some "Default vocabulary") createdAt None true
+                Entities.makeVocabulary systemCollection "My Words" (Some "Default vocabulary") createdAt createdAt true
 
             let entry1 =
-                Entities.makeEntry defaultVocab "word1" createdAt None
+                Entities.makeEntry defaultVocab "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry defaultVocab "word2" createdAt None
+                Entities.makeEntry defaultVocab "word2" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -51,7 +51,7 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
                       Name = "My Words"
                       Description = Some "Default vocabulary"
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       EntryCount = 2 }
 
             Assert.Equal(expected, actual)
@@ -68,10 +68,10 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let defaultVocab =
-                Entities.makeVocabulary systemCollection "My Words" None createdAt None true
+                Entities.makeVocabulary systemCollection "My Words" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -90,7 +90,7 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
                       Name = "My Words"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       EntryCount = 0 }
 
             Assert.Equal(expected, actual)
@@ -107,10 +107,10 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Regular Collection" None createdAt None false
+                Entities.makeCollection user "Regular Collection" None createdAt createdAt false
 
             let regularVocab =
-                Entities.makeVocabulary collection "Regular Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Regular Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -138,19 +138,19 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
             let user2 = Entities.makeUser 101
 
             let user1SystemCollection =
-                Entities.makeCollection user1 "Unsorted" None createdAt None true
+                Entities.makeCollection user1 "Unsorted" None createdAt createdAt true
 
             let user2SystemCollection =
-                Entities.makeCollection user2 "Unsorted" None createdAt None true
+                Entities.makeCollection user2 "Unsorted" None createdAt createdAt true
 
             let user1DefaultVocab =
-                Entities.makeVocabulary user1SystemCollection "My Words" None createdAt None true
+                Entities.makeVocabulary user1SystemCollection "My Words" None createdAt createdAt true
 
             let user2DefaultVocab =
-                Entities.makeVocabulary user2SystemCollection "My Words" None createdAt None true
+                Entities.makeVocabulary user2SystemCollection "My Words" None createdAt createdAt true
 
             let user2Entry =
-                Entities.makeEntry user2DefaultVocab "word" createdAt None
+                Entities.makeEntry user2DefaultVocab "word" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -170,7 +170,7 @@ type CollectionsHierarchyGetDefaultVocabularySummaryByUserIdTests(fixture: Wordf
                       Name = "My Words"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       EntryCount = 0 }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetVocabulariesWithEntryCountByCollectionIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/CollectionsHierarchy/GetVocabulariesWithEntryCountByCollectionIdTests.fs
@@ -22,16 +22,16 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user = Entities.makeUser 540
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocabulary "word1" createdAt None
+                Entities.makeEntry vocabulary "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocabulary "word2" createdAt None
+                Entities.makeEntry vocabulary "word2" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -50,7 +50,7 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
                     Name = "Vocabulary"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     EntryCount = 2 } ]
 
             Assert.Equal<CollectionsHierarchy.VocabularyWithEntryCount list>(expected, actual)
@@ -67,13 +67,13 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user = Entities.makeUser 547
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -91,7 +91,7 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     EntryCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.VocabularyWithEntryCount list>(expected, actual)
@@ -128,10 +128,10 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user2 = Entities.makeUser 543
 
             let user2Collection =
-                Entities.makeCollection user2 "User2 Collection" None createdAt None false
+                Entities.makeCollection user2 "User2 Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary user2Collection "Vocab" None createdAt None false
+                Entities.makeVocabulary user2Collection "Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -158,10 +158,10 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user = Entities.makeUser 544
 
             let systemCollection =
-                Entities.makeCollection user "System" None createdAt None true
+                Entities.makeCollection user "System" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocab" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -190,7 +190,7 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user = Entities.makeUser 545
 
             let collection =
-                Entities.makeCollection user "Empty Collection" None createdAt None false
+                Entities.makeCollection user "Empty Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -206,7 +206,7 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
         }
 
     [<Fact>]
-    member _.``getVocabulariesWithEntryCountByCollectionIdAsync returns vocabularies sorted by UpdatedAt DESC NULLS LAST then Id``
+    member _.``getVocabulariesWithEntryCountByCollectionIdAsync returns vocabularies sorted by UpdatedAt DESC then Id``
         ()
         =
         task {
@@ -224,16 +224,16 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
             let user = Entities.makeUser 546
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let vocabularyWithLateUpdate =
-                Entities.makeVocabulary collection "Beta" None createdAt (Some updatedAtLater) false
+                Entities.makeVocabulary collection "Beta" None createdAt updatedAtLater false
 
             let vocabularyWithEarlyUpdate =
-                Entities.makeVocabulary collection "Alpha" None createdAt (Some updatedAtEarlier) false
+                Entities.makeVocabulary collection "Alpha" None createdAt updatedAtEarlier false
 
             let vocabularyWithNullUpdate =
-                Entities.makeVocabulary collection "Gamma" None createdAt None false
+                Entities.makeVocabulary collection "Gamma" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -254,19 +254,19 @@ type CollectionsHierarchyGetVocabulariesWithEntryCountByCollectionIdTests(fixtur
                     Name = "Beta"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAtLater
+                    UpdatedAt = updatedAtLater
                     EntryCount = 0 }
                   { Id = vocabularyWithEarlyUpdate.Id
                     Name = "Alpha"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAtEarlier
+                    UpdatedAt = updatedAtEarlier
                     EntryCount = 0 }
                   { Id = vocabularyWithNullUpdate.Id
                     Name = "Gamma"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     EntryCount = 0 } ]
 
             Assert.Equal<CollectionsHierarchy.VocabularyWithEntryCount list>(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Definitions/CreateDefinitionsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Definitions/CreateDefinitionsTests.fs
@@ -25,13 +25,13 @@ type CreateDefinitionsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 400
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -125,13 +125,13 @@ type CreateDefinitionsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 401
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -168,13 +168,13 @@ type CreateDefinitionsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 402
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ordered" createdAt None
+                Entities.makeEntry vocabulary "ordered" createdAt createdAt
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/CreateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/CreateEntryTests.fs
@@ -25,10 +25,10 @@ type CreateEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 300
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -52,7 +52,7 @@ type CreateEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = vocabulary.Id
                       EntryText = "serendipity"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equivalent(expected, actualEntry)
         }

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/DeleteEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/DeleteEntryTests.fs
@@ -22,13 +22,13 @@ type DeleteEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 305
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "deleteme" createdAt None
+                Entities.makeEntry vocabulary "deleteme" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -71,16 +71,16 @@ type DeleteEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 306
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocabulary "cascade1" createdAt None
+                Entities.makeEntry vocabulary "cascade1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocabulary "cascade2" createdAt None
+                Entities.makeEntry vocabulary "cascade2" createdAt createdAt
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/GetEntryByTextAndVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/GetEntryByTextAndVocabularyIdTests.fs
@@ -22,13 +22,13 @@ type GetEntryByTextAndVocabularyIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 307
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -45,7 +45,7 @@ type GetEntryByTextAndVocabularyIdTests(fixture: WordfolioTestFixture) =
                       VocabularyId = vocabulary.Id
                       EntryText = "serendipity"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -61,13 +61,13 @@ type GetEntryByTextAndVocabularyIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 308
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let _ =
-                Entities.makeEntry vocabulary "ephemeral" createdAt None
+                Entities.makeEntry vocabulary "ephemeral" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -92,16 +92,16 @@ type GetEntryByTextAndVocabularyIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 309
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary1 =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let vocabulary2 =
-                Entities.makeVocabulary collection "Vocabulary 2" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 2" None createdAt createdAt false
 
             let _ =
-                Entities.makeEntry vocabulary1 "serendipity" createdAt None
+                Entities.makeEntry vocabulary1 "serendipity" createdAt createdAt
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/HasVocabularyAccessInCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/HasVocabularyAccessInCollectionTests.fs
@@ -24,10 +24,10 @@ type HasVocabularyAccessInCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 319
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -56,13 +56,13 @@ type HasVocabularyAccessInCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 320
 
             let collectionA =
-                Entities.makeCollection user "Collection A" None createdAt None false
+                Entities.makeCollection user "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection user "Collection B" None createdAt None false
+                Entities.makeCollection user "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionA "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collectionA "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -90,10 +90,10 @@ type HasVocabularyAccessInCollectionTests(fixture: WordfolioTestFixture) =
             let user2 = Entities.makeUser 322
 
             let collection =
-                Entities.makeCollection user1 "Collection 1" None createdAt None false
+                Entities.makeCollection user1 "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -132,10 +132,10 @@ type HasVocabularyAccessInCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 323
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -162,10 +162,10 @@ type HasVocabularyAccessInCollectionTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 324
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/HasVocabularyAccessTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/HasVocabularyAccessTests.fs
@@ -22,10 +22,10 @@ type HasVocabularyAccessTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 310
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" (Some "Description") createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" (Some "Description") createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -51,10 +51,10 @@ type HasVocabularyAccessTests(fixture: WordfolioTestFixture) =
             let user2 = Entities.makeUser 312
 
             let collection =
-                Entities.makeCollection user1 "Collection 1" None createdAt None false
+                Entities.makeCollection user1 "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -98,10 +98,10 @@ type HasVocabularyAccessTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 314
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -126,10 +126,10 @@ type HasVocabularyAccessTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 315
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -156,10 +156,10 @@ type HasVocabularyAccessTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 316
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/MoveEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/MoveEntryTests.fs
@@ -28,16 +28,16 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 317
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None createdAt None false
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None createdAt None false
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "move-me" createdAt None
+                Entities.makeEntry sourceVocabulary "move-me" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -65,7 +65,7 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = targetVocabulary.Id
                       EntryText = "move-me"
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt }
+                      UpdatedAt = updatedAt }
 
             Assert.Equal(expected, actual)
         }
@@ -103,19 +103,19 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 318
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None createdAt None false
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None createdAt None false
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let anotherVocabulary =
-                Entities.makeVocabulary collection "Another" None createdAt None false
+                Entities.makeVocabulary collection "Another" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "move-me" createdAt None
+                Entities.makeEntry sourceVocabulary "move-me" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -143,7 +143,7 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = sourceVocabulary.Id
                       EntryText = "move-me"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -162,13 +162,13 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 326
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None createdAt None false
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "move-me" createdAt None
+                Entities.makeEntry sourceVocabulary "move-me" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -198,7 +198,7 @@ type MoveEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = sourceVocabulary.Id
                       EntryText = "move-me"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/UpdateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Entries/UpdateEntryTests.fs
@@ -25,13 +25,13 @@ type UpdateEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 304
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "original" createdAt None
+                Entities.makeEntry vocabulary "original" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -55,7 +55,7 @@ type UpdateEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = vocabulary.Id
                       EntryText = "updated"
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt }
+                      UpdatedAt = updatedAt }
 
             Assert.Equal(expected, actual)
         }
@@ -92,16 +92,16 @@ type UpdateEntryTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 325
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let targetEntry =
-                Entities.makeEntry vocabulary "target-original" createdAt None
+                Entities.makeEntry vocabulary "target-original" createdAt createdAt
 
             let untouchedEntry =
-                Entities.makeEntry vocabulary "untouched" createdAt None
+                Entities.makeEntry vocabulary "untouched" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -126,7 +126,7 @@ type UpdateEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = vocabulary.Id
                       EntryText = "target-updated"
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt }
+                      UpdatedAt = updatedAt }
 
             let expectedUntouchedEntry: Entry option =
                 Some
@@ -134,7 +134,7 @@ type UpdateEntryTests(fixture: WordfolioTestFixture) =
                       VocabularyId = vocabulary.Id
                       EntryText = "untouched"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expectedTargetEntry, actualTargetEntry)
             Assert.Equal(expectedUntouchedEntry, actualUntouchedEntry)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/ClearEntryChildrenTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/ClearEntryChildrenTests.fs
@@ -23,13 +23,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 500
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ephemeral" createdAt None
+                Entities.makeEntry vocabulary "ephemeral" createdAt createdAt
 
             let _definition1 =
                 Entities.makeDefinition entry "Lasting for a short time" Definitions.DefinitionSource.Api 0
@@ -66,13 +66,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 501
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             let _translation1 =
                 Entities.makeTranslation entry "счастливый случай" Translations.TranslationSource.Api 0
@@ -109,13 +109,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 502
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ubiquitous" createdAt None
+                Entities.makeEntry vocabulary "ubiquitous" createdAt createdAt
 
             let _definition =
                 Entities.makeDefinition entry "Present everywhere" Definitions.DefinitionSource.Api 0
@@ -157,13 +157,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 503
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "meticulous" createdAt None
+                Entities.makeEntry vocabulary "meticulous" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Careful about details" Definitions.DefinitionSource.Api 0
@@ -208,13 +208,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 504
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "tenacious" createdAt None
+                Entities.makeEntry vocabulary "tenacious" createdAt createdAt
 
             let translation =
                 Entities.makeTranslation entry "упорный" Translations.TranslationSource.Manual 0
@@ -259,13 +259,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 507
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "standalone" createdAt None
+                Entities.makeEntry vocabulary "standalone" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -287,7 +287,7 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
                     VocabularyId = vocabulary.Id
                     EntryText = "standalone"
                     CreatedAt = createdAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = createdAt } ]
 
             Assert.Equal<Entry list>(expectedEntries, actualEntries)
         }
@@ -303,13 +303,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 505
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "solitary" createdAt None
+                Entities.makeEntry vocabulary "solitary" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Alone" Definitions.DefinitionSource.Manual 0
@@ -353,13 +353,13 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 506
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocabulary "resilient" createdAt None
+                Entities.makeEntry vocabulary "resilient" createdAt createdAt
 
             let _definition1 =
                 Entities.makeDefinition entry1 "Able to recover" Definitions.DefinitionSource.Api 0
@@ -368,7 +368,7 @@ type EntriesHierarchyClearEntryChildrenTests(fixture: WordfolioTestFixture) =
                 Entities.makeTranslation entry1 "устойчивый" Translations.TranslationSource.Manual 0
 
             let entry2 =
-                Entities.makeEntry vocabulary "benevolent" createdAt None
+                Entities.makeEntry vocabulary "benevolent" createdAt createdAt
 
             let definition2 =
                 Entities.makeDefinition entry2 "Kind and generous" Definitions.DefinitionSource.Manual 0

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/GetEntriesHierarchyByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/GetEntriesHierarchyByVocabularyIdTests.fs
@@ -23,10 +23,10 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Col" None createdAt None false
+                Entities.makeCollection user "Col" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Vocab" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -56,13 +56,13 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Col" None createdAt None false
+                Entities.makeCollection user "Col" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Vocab" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "happy accident" Definitions.DefinitionSource.Api 1
@@ -94,7 +94,7 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
                         VocabularyId = vocabulary.Id
                         EntryText = "serendipity"
                         CreatedAt = createdAt
-                        UpdatedAt = None }
+                        UpdatedAt = createdAt }
                     Definitions =
                       [ { Definition =
                             { Id = definition.Id
@@ -131,19 +131,19 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Col" None createdAt None false
+                Entities.makeCollection user "Col" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection "Vocab1" None createdAt None false
+                Entities.makeVocabulary collection "Vocab1" None createdAt createdAt false
 
             let vocab2 =
-                Entities.makeVocabulary collection "Vocab2" None createdAt None false
+                Entities.makeVocabulary collection "Vocab2" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocab1 "word1" createdAt None
+                Entities.makeEntry vocab1 "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocab2 "word2" createdAt None
+                Entities.makeEntry vocab2 "word2" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -163,7 +163,7 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
                         VocabularyId = vocab1.Id
                         EntryText = "word1"
                         CreatedAt = createdAt
-                        UpdatedAt = None }
+                        UpdatedAt = createdAt }
                     Definitions = []
                     Translations = [] } ]
 
@@ -186,16 +186,16 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
             let user = Entities.makeUser 101
 
             let collection =
-                Entities.makeCollection user "Col" None earlierCreatedAt None false
+                Entities.makeCollection user "Col" None earlierCreatedAt earlierCreatedAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocab" None earlierCreatedAt None false
+                Entities.makeVocabulary collection "Vocab" None earlierCreatedAt earlierCreatedAt false
 
             let olderEntry =
-                Entities.makeEntry vocabulary "older" earlierCreatedAt None
+                Entities.makeEntry vocabulary "older" earlierCreatedAt earlierCreatedAt
 
             let newerEntry =
-                Entities.makeEntry vocabulary "newer" laterCreatedAt None
+                Entities.makeEntry vocabulary "newer" laterCreatedAt laterCreatedAt
 
             let olderDefinition =
                 Entities.makeDefinition olderEntry "older meaning" Definitions.DefinitionSource.Manual 0
@@ -223,11 +223,26 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
 
             let expected: EntriesHierarchy.EntryHierarchy list =
                 [ { Entry =
+                      { Id = newerEntry.Id
+                        VocabularyId = vocabulary.Id
+                        EntryText = "newer"
+                        CreatedAt = laterCreatedAt
+                        UpdatedAt = laterCreatedAt }
+                    Definitions = []
+                    Translations =
+                      [ { Translation =
+                            { Id = newerTranslation.Id
+                              EntryId = newerEntry.Id
+                              TranslationText = "новее"
+                              Source = Translations.TranslationSource.Api
+                              DisplayOrder = 0 }
+                          Examples = [] } ] }
+                  { Entry =
                       { Id = olderEntry.Id
                         VocabularyId = vocabulary.Id
                         EntryText = "older"
                         CreatedAt = earlierCreatedAt
-                        UpdatedAt = None }
+                        UpdatedAt = earlierCreatedAt }
                     Definitions =
                       [ { Definition =
                             { Id = olderDefinition.Id
@@ -241,30 +256,13 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
                                 TranslationId = None
                                 ExampleText = "older example"
                                 Source = Examples.ExampleSource.Api } ] } ]
-                    Translations = [] }
-                  { Entry =
-                      { Id = newerEntry.Id
-                        VocabularyId = vocabulary.Id
-                        EntryText = "newer"
-                        CreatedAt = laterCreatedAt
-                        UpdatedAt = None }
-                    Definitions = []
-                    Translations =
-                      [ { Translation =
-                            { Id = newerTranslation.Id
-                              EntryId = newerEntry.Id
-                              TranslationText = "новее"
-                              Source = Translations.TranslationSource.Api
-                              DisplayOrder = 0 }
-                          Examples = [] } ] } ]
+                    Translations = [] } ]
 
             Assert.Equal<EntriesHierarchy.EntryHierarchy list>(expected, actual)
         }
 
     [<Fact>]
-    member _.``getEntriesHierarchyByVocabularyIdAsync returns entries ordered by UpdatedAt desc nulls last then by Id``
-        ()
-        =
+    member _.``getEntriesHierarchyByVocabularyIdAsync returns entries ordered by UpdatedAt desc then by Id``() =
         task {
             do! fixture.ResetDatabaseAsync()
 
@@ -280,22 +278,22 @@ type EntriesHierarchyGetEntriesHierarchyByVocabularyIdTests(fixture: WordfolioTe
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Col" None createdAt None false
+                Entities.makeCollection user "Col" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Vocab" None createdAt createdAt false
 
             let entryNullUpdatedFirst =
-                Entities.makeEntry vocabulary "never-updated-1" createdAt None
+                Entities.makeEntry vocabulary "never-updated-1" createdAt createdAt
 
             let entryNullUpdatedSecond =
-                Entities.makeEntry vocabulary "never-updated-2" createdAt None
+                Entities.makeEntry vocabulary "never-updated-2" createdAt createdAt
 
             let entryEarlierUpdated =
-                Entities.makeEntry vocabulary "earlier-updated" createdAt (Some earlierUpdatedAt)
+                Entities.makeEntry vocabulary "earlier-updated" createdAt earlierUpdatedAt
 
             let entryLaterUpdated =
-                Entities.makeEntry vocabulary "later-updated" createdAt (Some laterUpdatedAt)
+                Entities.makeEntry vocabulary "later-updated" createdAt laterUpdatedAt
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/GetEntryByIdWithHierarchyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/EntriesHierarchy/GetEntryByIdWithHierarchyTests.fs
@@ -35,13 +35,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 400
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "solitary" createdAt None
+                Entities.makeEntry vocabulary "solitary" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -59,7 +59,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "solitary"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions = []
                       Translations = [] }
 
@@ -77,13 +77,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 401
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ephemeral" createdAt None
+                Entities.makeEntry vocabulary "ephemeral" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Lasting for a very short time" Definitions.DefinitionSource.Manual 0
@@ -104,7 +104,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "ephemeral"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions =
                         [ { Definition =
                               { Id = definition.Id
@@ -129,13 +129,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 402
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             let translation =
                 Entities.makeTranslation entry "счастливая случайность" Translations.TranslationSource.Api 0
@@ -156,7 +156,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "serendipity"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions = []
                       Translations =
                         [ { Translation =
@@ -181,13 +181,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 403
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ubiquitous" createdAt None
+                Entities.makeEntry vocabulary "ubiquitous" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Present everywhere" Definitions.DefinitionSource.Api 0
@@ -217,7 +217,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "ubiquitous"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions =
                         [ { Definition =
                               { Id = definition.Id
@@ -252,13 +252,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 404
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "meticulous" createdAt None
+                Entities.makeEntry vocabulary "meticulous" createdAt createdAt
 
             let translation =
                 Entities.makeTranslation entry "тщательный" Translations.TranslationSource.Manual 0
@@ -288,7 +288,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "meticulous"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions = []
                       Translations =
                         [ { Translation =
@@ -323,13 +323,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 405
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "resilient" createdAt None
+                Entities.makeEntry vocabulary "resilient" createdAt createdAt
 
             let definition1 =
                 Entities.makeDefinition entry "Able to recover quickly" Definitions.DefinitionSource.Api 0
@@ -359,7 +359,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "resilient"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions =
                         [ { Definition =
                               { Id = definition1.Id
@@ -405,13 +405,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 406
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "tenacious" createdAt None
+                Entities.makeEntry vocabulary "tenacious" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Holding fast" Definitions.DefinitionSource.Api 0
@@ -441,7 +441,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "tenacious"
                           CreatedAt = createdAt
-                          UpdatedAt = None }
+                          UpdatedAt = createdAt }
                       Definitions =
                         [ { Definition =
                               { Id = definition.Id
@@ -486,13 +486,13 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
             let user = Entities.makeUser 407
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "benevolent" createdAt (Some updatedAt)
+                Entities.makeEntry vocabulary "benevolent" createdAt updatedAt
 
             do!
                 fixture.Seeder
@@ -510,7 +510,7 @@ type EntriesHierarchyGetEntryByIdWithHierarchyTests(fixture: WordfolioTestFixtur
                           VocabularyId = vocabulary.Id
                           EntryText = "benevolent"
                           CreatedAt = createdAt
-                          UpdatedAt = Some updatedAt }
+                          UpdatedAt = updatedAt }
                       Definitions = []
                       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Examples/CreateExamplesTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Examples/CreateExamplesTests.fs
@@ -25,13 +25,13 @@ type CreateExamplesTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 600
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "ephemeral" createdAt None
+                Entities.makeEntry vocabulary "ephemeral" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Lasting for a very short time" Definitions.DefinitionSource.Manual 1
@@ -87,13 +87,13 @@ type CreateExamplesTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 601
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             let translation =
                 Entities.makeTranslation entry "fortunate chance" Translations.TranslationSource.Manual 1
@@ -201,13 +201,13 @@ type CreateExamplesTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 602
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Definition" Definitions.DefinitionSource.Manual 1
@@ -266,13 +266,13 @@ type CreateExamplesTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 609
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition entry "Definition" Definitions.DefinitionSource.Manual 1
@@ -307,13 +307,13 @@ type CreateExamplesTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 610
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             let translation =
                 Entities.makeTranslation entry "Translation" Translations.TranslationSource.Manual 1

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Translations/CreateTranslationsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Translations/CreateTranslationsTests.fs
@@ -25,13 +25,13 @@ type CreateTranslationsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 500
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -105,13 +105,13 @@ type CreateTranslationsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 511
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "serendipity" createdAt None
+                Entities.makeEntry vocabulary "serendipity" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -187,13 +187,13 @@ type CreateTranslationsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 501
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             do!
                 fixture.Seeder
@@ -230,13 +230,13 @@ type CreateTranslationsTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 506
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary 1" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary 1" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "test" createdAt None
+                Entities.makeEntry vocabulary "test" createdAt createdAt
 
             let _ =
                 Entities.makeTranslation entry "Translation 1" Translations.TranslationSource.Manual 1

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/CreateDefaultVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/CreateDefaultVocabularyTests.fs
@@ -25,7 +25,7 @@ type CreateDefaultVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -52,7 +52,7 @@ type CreateDefaultVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Unsorted"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = true }
 
             Assert.Equivalent(expected, actualVocabulary)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/CreateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/CreateVocabularyTests.fs
@@ -25,7 +25,7 @@ type CreateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 200
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -51,7 +51,7 @@ type CreateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = Some "Test vocabulary"
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equivalent(expected, actualVocabulary)
@@ -68,7 +68,7 @@ type CreateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 203
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -94,7 +94,7 @@ type CreateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equivalent(expected, actualVocabulary)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/DeleteVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/DeleteVocabularyTests.fs
@@ -22,10 +22,10 @@ type DeleteVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 202
 
             let collection =
-                Entities.makeCollection user "Collection 3" None createdAt None false
+                Entities.makeCollection user "Collection 3" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary to delete" None createdAt None false
+                Entities.makeVocabulary collection "Vocabulary to delete" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -68,10 +68,10 @@ type DeleteVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -95,7 +95,7 @@ type DeleteVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Default"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = true }
 
             Assert.Equal(expected, actual)
@@ -112,10 +112,10 @@ type DeleteVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -139,7 +139,7 @@ type DeleteVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetDefaultVocabularyByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetDefaultVocabularyByUserIdTests.fs
@@ -23,13 +23,13 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Unsorted" None createdAt None true
+                Entities.makeVocabulary collection "Unsorted" None createdAt createdAt true
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -49,7 +49,7 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
                       Name = "Unsorted"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -65,10 +65,10 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -98,16 +98,16 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
             let user2 = Entities.makeUser 101
 
             let collection1 =
-                Entities.makeCollection user1 "Collection 1" None createdAt None false
+                Entities.makeCollection user1 "Collection 1" None createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection user2 "Collection 2" None createdAt None false
+                Entities.makeCollection user2 "Collection 2" None createdAt createdAt false
 
             let user1DefaultVocabulary =
-                Entities.makeVocabulary collection1 "User 1 Default" None createdAt None true
+                Entities.makeVocabulary collection1 "User 1 Default" None createdAt createdAt true
 
             let _ =
-                Entities.makeVocabulary collection2 "User 2 Default" None createdAt None true
+                Entities.makeVocabulary collection2 "User 2 Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -125,7 +125,7 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
                       Name = "User 1 Default"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -141,13 +141,13 @@ type GetDefaultVocabularyByUserIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection" None createdAt None false
+                Entities.makeCollection user "Collection" None createdAt createdAt false
 
             let defaultVocabulary1 =
-                Entities.makeVocabulary collection "Default 1" None createdAt None true
+                Entities.makeVocabulary collection "Default 1" None createdAt createdAt true
 
             let defaultVocabulary2 =
-                Entities.makeVocabulary collection "Default 2" None createdAt None true
+                Entities.makeVocabulary collection "Default 2" None createdAt createdAt true
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetVocabulariesByCollectionIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetVocabulariesByCollectionIdTests.fs
@@ -22,19 +22,19 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 200
 
             let collection1 =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection user "Collection 2" None createdAt None false
+                Entities.makeCollection user "Collection 2" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection1 "Vocab 1" None createdAt None false
+                Entities.makeVocabulary collection1 "Vocab 1" None createdAt createdAt false
 
             let vocab2 =
-                Entities.makeVocabulary collection1 "Vocab 2" None createdAt None false
+                Entities.makeVocabulary collection1 "Vocab 2" None createdAt createdAt false
 
             let _ =
-                Entities.makeVocabulary collection2 "Vocab 3" None createdAt None false
+                Entities.makeVocabulary collection2 "Vocab 3" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -51,13 +51,13 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
                     Name = "Vocab 1"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None }
+                    UpdatedAt = createdAt }
                   { Id = vocab2.Id
                     CollectionId = collection1.Id
                     Name = "Vocab 2"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = createdAt } ]
 
             Assert.Equivalent(expected, actual)
         }
@@ -73,7 +73,7 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 200
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -98,13 +98,13 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -123,7 +123,7 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = createdAt } ]
 
             Assert.Equal<Vocabularies.Vocabulary list>(expected, actual)
         }
@@ -139,10 +139,10 @@ type GetVocabulariesByCollectionIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetVocabularyByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/GetVocabularyByIdTests.fs
@@ -22,10 +22,10 @@ type GetVocabularyByIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 200
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "My Vocabulary" (Some "Test vocabulary") createdAt None false
+                Entities.makeVocabulary collection "My Vocabulary" (Some "Test vocabulary") createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -43,7 +43,7 @@ type GetVocabularyByIdTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = Some "Test vocabulary"
                       CreatedAt = createdAt
-                      UpdatedAt = None }
+                      UpdatedAt = createdAt }
 
             Assert.Equal(expected, actual)
         }
@@ -71,10 +71,10 @@ type GetVocabularyByIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -101,10 +101,10 @@ type GetVocabularyByIdTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/MoveVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/MoveVocabularyTests.fs
@@ -28,13 +28,13 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 400
 
             let sourceCollection =
-                Entities.makeCollection user "Source" None createdAt None false
+                Entities.makeCollection user "Source" None createdAt createdAt false
 
             let targetCollection =
-                Entities.makeCollection user "Target" None createdAt None false
+                Entities.makeCollection user "Target" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt None false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -62,7 +62,7 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt
+                      UpdatedAt = updatedAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -101,16 +101,16 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 401
 
             let sourceCollection =
-                Entities.makeCollection user "Source" None createdAt None false
+                Entities.makeCollection user "Source" None createdAt createdAt false
 
             let targetCollection =
-                Entities.makeCollection user "Target" None createdAt None false
+                Entities.makeCollection user "Target" None createdAt createdAt false
 
             let otherCollection =
-                Entities.makeCollection user "Other" None createdAt None false
+                Entities.makeCollection user "Other" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt None false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -138,7 +138,7 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -158,10 +158,10 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 402
 
             let sourceCollection =
-                Entities.makeCollection user "Source" None createdAt None false
+                Entities.makeCollection user "Source" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt None false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -191,7 +191,7 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -211,13 +211,13 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 404
 
             let sourceCollection =
-                Entities.makeCollection user "Source" None createdAt None false
+                Entities.makeCollection user "Source" None createdAt createdAt false
 
             let systemCollection =
-                Entities.makeCollection user "System" None createdAt None true
+                Entities.makeCollection user "System" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt None false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -245,7 +245,7 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -265,13 +265,13 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 403
 
             let sourceCollection =
-                Entities.makeCollection user "Source" None createdAt None false
+                Entities.makeCollection user "Source" None createdAt createdAt false
 
             let targetCollection =
-                Entities.makeCollection user "Target" None createdAt None false
+                Entities.makeCollection user "Target" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary sourceCollection "Default" None createdAt None true
+                Entities.makeVocabulary sourceCollection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -299,7 +299,7 @@ type MoveVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Default"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = true }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/UpdateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Vocabularies/UpdateVocabularyTests.fs
@@ -25,10 +25,16 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 201
 
             let collection =
-                Entities.makeCollection user "Collection 2" None createdAt None false
+                Entities.makeCollection user "Collection 2" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Original Name" (Some "Original Description") createdAt None false
+                Entities.makeVocabulary
+                    collection
+                    "Original Name"
+                    (Some "Original Description")
+                    createdAt
+                    createdAt
+                    false
 
             do!
                 fixture.Seeder
@@ -54,7 +60,7 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Updated Name"
                       Description = Some "Updated Description"
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt
+                      UpdatedAt = updatedAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -74,10 +80,16 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 204
 
             let collection =
-                Entities.makeCollection user "Collection 4" None createdAt None false
+                Entities.makeCollection user "Collection 4" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary Name" (Some "Original Description") createdAt None false
+                Entities.makeVocabulary
+                    collection
+                    "Vocabulary Name"
+                    (Some "Original Description")
+                    createdAt
+                    createdAt
+                    false
 
             do!
                 fixture.Seeder
@@ -103,7 +115,7 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Vocabulary Name"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = Some updatedAt
+                      UpdatedAt = updatedAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)
@@ -142,10 +154,10 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let collection =
-                Entities.makeCollection user "Collection 1" None createdAt None false
+                Entities.makeCollection user "Collection 1" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             do!
                 fixture.Seeder
@@ -173,7 +185,7 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Default"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = true }
 
             Assert.Equal(expected, actual)
@@ -193,10 +205,10 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
             let user = Entities.makeUser 100
 
             let systemCollection =
-                Entities.makeCollection user "Unsorted" None createdAt None true
+                Entities.makeCollection user "Unsorted" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt None false
+                Entities.makeVocabulary systemCollection "Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.Seeder
@@ -224,7 +236,7 @@ type UpdateVocabularyTests(fixture: WordfolioTestFixture) =
                       Name = "Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Collections.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Collections.fs
@@ -16,7 +16,7 @@ type internal CollectionRecord =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsSystem: bool }
 
 type Collection =
@@ -25,7 +25,7 @@ type Collection =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type CreateCollectionParameters =
     { UserId: int
@@ -45,7 +45,7 @@ let private fromRecord(record: CollectionRecord) : Collection =
       Name = record.Name
       Description = record.Description
       CreatedAt = record.CreatedAt
-      UpdatedAt = record.UpdatedAt |> Option.ofNullable }
+      UpdatedAt = record.UpdatedAt }
 
 [<CLIMutable>]
 type internal CollectionInsertParameters =
@@ -53,6 +53,7 @@ type internal CollectionInsertParameters =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
+      UpdatedAt: DateTimeOffset
       IsSystem: bool }
 
 let createCollectionAsync
@@ -71,6 +72,7 @@ let createCollectionAsync
               Name = parameters.Name
               Description = parameters.Description
               CreatedAt = parameters.CreatedAt
+              UpdatedAt = parameters.CreatedAt
               IsSystem = false }
 
         let! record =
@@ -144,7 +146,7 @@ let updateCollectionAsync
                 for c in collectionsTable do
                     setColumn c.Name parameters.Name
                     setColumn c.Description parameters.Description
-                    setColumn c.UpdatedAt (Nullable parameters.UpdatedAt)
+                    setColumn c.UpdatedAt parameters.UpdatedAt
 
                     where(
                         c.Id = parameters.Id
@@ -214,6 +216,7 @@ let createDefaultCollectionAsync
               Name = parameters.Name
               Description = parameters.Description
               CreatedAt = parameters.CreatedAt
+              UpdatedAt = parameters.CreatedAt
               IsSystem = true }
 
         let! record =

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/CollectionsHierarchy.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/CollectionsHierarchy.fs
@@ -12,7 +12,7 @@ type VocabularyWithEntryCount =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       EntryCount: int }
 
 type CollectionWithVocabularies =
@@ -21,7 +21,7 @@ type CollectionWithVocabularies =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       Vocabularies: VocabularyWithEntryCount list }
 
 type CollectionWithVocabularyCount =
@@ -30,7 +30,7 @@ type CollectionWithVocabularyCount =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       VocabularyCount: int }
 
 [<CLIMutable>]
@@ -40,7 +40,7 @@ type internal CollectionWithVocabularyCountRecord =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       VocabularyCount: int }
 
 [<CLIMutable>]
@@ -50,7 +50,7 @@ type internal CollectionRecord =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsSystem: bool }
 
 [<CLIMutable>]
@@ -59,7 +59,7 @@ type internal VocabularyRecord =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsDefault: bool
       EntryCount: int }
 
@@ -77,7 +77,7 @@ let private toCollectionWithVocabularies
                   Name = v.Name
                   Description = v.Description
                   CreatedAt = v.CreatedAt
-                  UpdatedAt = v.UpdatedAt |> Option.ofNullable
+                  UpdatedAt = v.UpdatedAt
                   EntryCount = v.EntryCount })
             |> Seq.toList
 
@@ -86,9 +86,7 @@ let private toCollectionWithVocabularies
           Name = collection.Name
           Description = collection.Description
           CreatedAt = collection.CreatedAt
-          UpdatedAt =
-            collection.UpdatedAt
-            |> Option.ofNullable
+          UpdatedAt = collection.UpdatedAt
           Vocabularies = vocabularies })
     |> Seq.toList
 
@@ -175,7 +173,7 @@ let getCollectionsWithVocabularyCountByUserIdAsync
                   Name = c.Name
                   Description = c.Description
                   CreatedAt = c.CreatedAt
-                  UpdatedAt = c.UpdatedAt |> Option.ofNullable
+                  UpdatedAt = c.UpdatedAt
                   VocabularyCount = c.VocabularyCount }
                 : CollectionWithVocabularyCount)
             |> Seq.toList
@@ -225,7 +223,7 @@ let getVocabulariesWithEntryCountByCollectionIdAsync
                   Name = v.Name
                   Description = v.Description
                   CreatedAt = v.CreatedAt
-                  UpdatedAt = v.UpdatedAt |> Option.ofNullable
+                  UpdatedAt = v.UpdatedAt
                   EntryCount = v.EntryCount })
             |> Seq.toList
     }
@@ -269,6 +267,6 @@ let getDefaultVocabularySummaryByUserIdAsync
                   Name = v.Name
                   Description = v.Description
                   CreatedAt = v.CreatedAt
-                  UpdatedAt = v.UpdatedAt |> Option.ofNullable
+                  UpdatedAt = v.UpdatedAt
                   EntryCount = v.EntryCount })
     }

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Entries.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Entries.fs
@@ -16,19 +16,26 @@ type internal EntryRecord =
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset> }
+      UpdatedAt: DateTimeOffset }
 
 type Entry =
     { Id: int
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type CreateEntryParameters =
     { VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset }
+
+[<CLIMutable>]
+type internal EntryInsertParameters =
+    { VocabularyId: int
+      EntryText: string
+      CreatedAt: DateTimeOffset
+      UpdatedAt: DateTimeOffset }
 
 type UpdateEntryParameters =
     { Id: int
@@ -46,11 +53,7 @@ let private fromRecord(record: EntryRecord) : Entry =
       VocabularyId = record.VocabularyId
       EntryText = record.EntryText
       CreatedAt = record.CreatedAt
-      UpdatedAt =
-        if record.UpdatedAt.HasValue then
-            Some record.UpdatedAt.Value
-        else
-            None }
+      UpdatedAt = record.UpdatedAt }
 
 let createEntryAsync
     (parameters: CreateEntryParameters)
@@ -60,15 +63,21 @@ let createEntryAsync
     : Task<int> =
     task {
         let entriesInsertTable =
-            table'<CreateEntryParameters> Schema.EntriesTable.Name
+            table'<EntryInsertParameters> Schema.EntriesTable.Name
             |> inSchema Schema.Name
+
+        let insertParameters: EntryInsertParameters =
+            { VocabularyId = parameters.VocabularyId
+              EntryText = parameters.EntryText
+              CreatedAt = parameters.CreatedAt
+              UpdatedAt = parameters.CreatedAt }
 
         let! record =
             insert {
                 into entriesInsertTable
-                values [ parameters ]
+                values [ insertParameters ]
             }
-            |> insertOutputSingleAsync<CreateEntryParameters, EntryRecord> connection transaction cancellationToken
+            |> insertOutputSingleAsync<EntryInsertParameters, EntryRecord> connection transaction cancellationToken
 
         return record.Id
     }
@@ -113,7 +122,7 @@ let updateEntryAsync
             update {
                 for e in entriesTable do
                     setColumn e.EntryText parameters.EntryText
-                    setColumn e.UpdatedAt (Nullable parameters.UpdatedAt)
+                    setColumn e.UpdatedAt parameters.UpdatedAt
                     where(e.Id = parameters.Id)
             }
             |> updateAsync connection transaction cancellationToken
@@ -136,7 +145,7 @@ let moveEntryAsync
             update {
                 for e in entriesTable do
                     setColumn e.VocabularyId parameters.NewVocabularyId
-                    setColumn e.UpdatedAt (Nullable parameters.UpdatedAt)
+                    setColumn e.UpdatedAt parameters.UpdatedAt
 
                     where(
                         e.Id = parameters.Id

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/EntriesHierarchy.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/EntriesHierarchy.fs
@@ -31,7 +31,7 @@ type private EntryRecord =
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset> }
+      UpdatedAt: DateTimeOffset }
 
 [<CLIMutable>]
 type private DefinitionRecord =
@@ -98,7 +98,7 @@ let private assembleEntriesWithHierarchy
               VocabularyId = entryRec.VocabularyId
               EntryText = entryRec.EntryText
               CreatedAt = entryRec.CreatedAt
-              UpdatedAt = entryRec.UpdatedAt |> Option.ofNullable }
+              UpdatedAt = entryRec.UpdatedAt }
 
         let definitionsWithExamples =
             match definitionsByEntry.TryFind(entryRec.Id) with

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Vocabularies.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Vocabularies.fs
@@ -15,7 +15,7 @@ type internal VocabularyRecord =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsDefault: bool }
 
 type Vocabulary =
@@ -24,7 +24,7 @@ type Vocabulary =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type CreateVocabularyParameters =
     { CollectionId: int
@@ -50,11 +50,7 @@ let private fromRecord(record: VocabularyRecord) : Vocabulary =
       Name = record.Name
       Description = record.Description
       CreatedAt = record.CreatedAt
-      UpdatedAt =
-        if record.UpdatedAt.HasValue then
-            Some record.UpdatedAt.Value
-        else
-            None }
+      UpdatedAt = record.UpdatedAt }
 
 let internal vocabulariesTable =
     table'<VocabularyRecord> Schema.VocabulariesTable.Name
@@ -66,6 +62,7 @@ type internal VocabularyInsertParameters =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
+      UpdatedAt: DateTimeOffset
       IsDefault: bool }
 
 [<CLIMutable>]
@@ -88,6 +85,7 @@ let createVocabularyAsync
               Name = parameters.Name
               Description = parameters.Description
               CreatedAt = parameters.CreatedAt
+              UpdatedAt = parameters.CreatedAt
               IsDefault = false }
 
         let! record =
@@ -191,7 +189,7 @@ let updateVocabularyAsync
                     {| Id = parameters.Id
                        Name = parameters.Name
                        Description = parameters.Description |> Option.toObj
-                       UpdatedAt = Nullable parameters.UpdatedAt |},
+                       UpdatedAt = parameters.UpdatedAt |},
                 transaction = transaction,
                 cancellationToken = cancellationToken
             )
@@ -315,6 +313,7 @@ let createDefaultVocabularyAsync
               Name = parameters.Name
               Description = parameters.Description
               CreatedAt = parameters.CreatedAt
+              UpdatedAt = parameters.CreatedAt
               IsDefault = true }
 
         let! record =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/CreateTests.fs
@@ -45,7 +45,7 @@ let makeCollection id userId name description createdAt =
       Name = name
       Description = description
       CreatedAt = createdAt
-      UpdatedAt = None }
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``creates collection with valid name``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/DeleteTests.fs
@@ -36,12 +36,14 @@ type TestEnv(getCollectionById: CollectionId -> Task<Collection option>, deleteC
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``deletes collection when owned by user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByIdTests.fs
@@ -25,12 +25,14 @@ type TestEnv(getCollectionById: CollectionId -> Task<Collection option>) =
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``returns collection when found and owned by user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByUserIdTests.fs
@@ -26,12 +26,14 @@ type TestEnv(getCollectionsByUserId: UserId -> Task<Collection list>) =
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``returns collections for user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/UpdateTests.fs
@@ -37,12 +37,15 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name description =
+    let createdAt =
+        DateTimeOffset.UtcNow.AddDays(-1)
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = name
       Description = description
-      CreatedAt = DateTimeOffset.UtcNow.AddDays(-1)
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``updates collection when owned by user``() =
@@ -98,7 +101,7 @@ let ``updates collection when owned by user``() =
             Assert.Equal(UserId 1, updated.UserId)
             Assert.Equal("New Name", updated.Name)
             Assert.Equal(Some "New Description", updated.Description)
-            Assert.Equal(Some now, updated.UpdatedAt)
+            Assert.Equal(now, updated.UpdatedAt)
             Assert.Equal(existingCollection.CreatedAt, updated.CreatedAt)
         | Error e -> failwith $"Expected Ok, got Error: {e}"
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetByUserIdTests.fs
@@ -49,7 +49,7 @@ let makeVocabularySummary vocabularyId name entryCount =
       Name = name
       Description = None
       CreatedAt = now
-      UpdatedAt = None
+      UpdatedAt = now
       EntryCount = entryCount }
 
 let makeCollectionSummary id name vocabularies =
@@ -57,7 +57,7 @@ let makeCollectionSummary id name vocabularies =
       Name = name
       Description = None
       CreatedAt = now
-      UpdatedAt = None
+      UpdatedAt = now
       Vocabularies = vocabularies }
 
 [<Fact>]

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetCollectionsWithVocabularyCountTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetCollectionsWithVocabularyCountTests.fs
@@ -33,7 +33,7 @@ let makeCollectionWithVocabularyCount id name vocabularyCount =
       Name = name
       Description = None
       CreatedAt = now
-      UpdatedAt = None
+      UpdatedAt = now
       VocabularyCount = vocabularyCount }
 
 [<Fact>]

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetVocabulariesWithEntryCountByCollectionIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/CollectionsHierarchy/GetVocabulariesWithEntryCountByCollectionIdTests.fs
@@ -34,7 +34,7 @@ let makeVocabulary vocabularyId name entryCount =
       Name = name
       Description = None
       CreatedAt = now
-      UpdatedAt = None
+      UpdatedAt = now
       EntryCount = entryCount }
 
 [<Fact>]

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/CreateTests.fs
@@ -120,19 +120,21 @@ type TestEnv
         member _.CreateDefaultCollection(parameters) = createDefaultCollection parameters
 
 let makeVocabulary id collectionId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeEntry id vocabularyId text createdAt definitions translations =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
       CreatedAt = createdAt
-      UpdatedAt = None
+      UpdatedAt = createdAt
       Definitions = definitions
       Translations = translations }
 
@@ -738,7 +740,7 @@ let ``creates entry when default vocabulary does not exist but default collectio
               Name = "[System] Unsorted"
               Description = None
               CreatedAt = now
-              UpdatedAt = None }
+              UpdatedAt = now }
 
         let env =
             TestEnv(

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
@@ -54,8 +54,8 @@ let makeEntry id vocabularyId text =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
@@ -51,11 +51,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
@@ -38,8 +38,8 @@ let makeEntry id vocabularyId entryText definitions translations =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = entryText
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = definitions
       Translations = translations }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
@@ -35,11 +35,13 @@ type TestEnv(getEntryById: EntryId -> Task<Entry option>, hasVocabularyAccess: H
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId entryText definitions translations =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = entryText
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = definitions
       Translations = translations }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
@@ -40,11 +40,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
@@ -43,8 +43,8 @@ let makeEntry id vocabularyId text =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetDraftsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetDraftsTests.fs
@@ -51,14 +51,14 @@ let private vocabulary: Vocabulary =
       Name = "[Default]"
       Description = None
       CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
-      UpdatedAt = None }
+      UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
 let private entry: Entry =
     { Id = EntryId 100
       VocabularyId = VocabularyId 10
       EntryText = "serendipity"
       CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
-      UpdatedAt = None
+      UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
       Definitions =
         [ { Id = DefinitionId 1
             DefinitionText = "happy accident"

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetDraftsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetDraftsTests.fs
@@ -45,20 +45,23 @@ type TestEnv
 
 let private userId = UserId 1
 
+let private timestamp =
+    DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
 let private vocabulary: Vocabulary =
     { Id = VocabularyId 10
       CollectionId = CollectionId 1
       Name = "[Default]"
       Description = None
-      CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
-      UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
+      CreatedAt = timestamp
+      UpdatedAt = timestamp }
 
 let private entry: Entry =
     { Id = EntryId 100
       VocabularyId = VocabularyId 10
       EntryText = "serendipity"
-      CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
-      UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions =
         [ { Id = DefinitionId 1
             DefinitionText = "happy accident"

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
@@ -52,7 +52,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text createdAt (updatedAt: DateTimeOffset) =
+let makeEntry id vocabularyId text createdAt updatedAt =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
@@ -52,7 +52,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text createdAt updatedAt =
+let makeEntry id vocabularyId text createdAt (updatedAt: DateTimeOffset) =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
@@ -67,10 +67,10 @@ let ``moves entry when user has access to source and target vocabularies``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let movedEntry =
-            makeEntry 10 200 "hello" now (Some now)
+            makeEntry 10 200 "hello" now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -148,7 +148,7 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when source vocabulary access is denied``() =
     task {
         let existingEntry =
-            makeEntry 10 100 "hello" DateTimeOffset.UtcNow None
+            makeEntry 10 100 "hello" DateTimeOffset.UtcNow DateTimeOffset.UtcNow
 
         let accessCallCount = ref 0
 
@@ -191,7 +191,7 @@ let ``returns EntryNotFound when source vocabulary access is denied``() =
 let ``returns VocabularyNotFoundOrAccessDenied when target vocabulary access is denied``() =
     task {
         let existingEntry =
-            makeEntry 10 100 "hello" DateTimeOffset.UtcNow None
+            makeEntry 10 100 "hello" DateTimeOffset.UtcNow DateTimeOffset.UtcNow
 
         let accessCallCount = ref 0
 
@@ -241,7 +241,7 @@ let ``throws when post-move entry fetch returns None``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -279,10 +279,10 @@ let ``move succeeds without duplicate checks in target vocabulary``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "duplicate-text" now None
+            makeEntry 10 100 "duplicate-text" now now
 
         let movedEntry =
-            makeEntry 10 200 "duplicate-text" now (Some now)
+            makeEntry 10 200 "duplicate-text" now now
 
         let getEntryByIdCallCount = ref 0
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
@@ -115,7 +115,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text definitions translations createdAt (updatedAt: DateTimeOffset) =
+let makeEntry id vocabularyId text definitions translations createdAt updatedAt =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
@@ -115,7 +115,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text definitions translations createdAt updatedAt =
+let makeEntry id vocabularyId text definitions translations createdAt (updatedAt: DateTimeOffset) =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
@@ -161,7 +161,7 @@ let ``updates entry with new definitions and translations``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "old" [] [] now None
+            makeEntry 1 10 "old" [] [] now now
 
         let example =
             makeExample 1 "example" ExampleSource.Custom
@@ -173,7 +173,7 @@ let ``updates entry with new definitions and translations``() =
             makeTranslation 20 "translation" TranslationSource.Manual 0 [ example ]
 
         let updatedEntry =
-            makeEntry 1 10 "new" [ definition ] [ translation ] now (Some now)
+            makeEntry 1 10 "new" [ definition ] [ translation ] now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -321,7 +321,7 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when user has no access``() =
     task {
         let entry =
-            makeEntry 1 10 "text" [] [] DateTimeOffset.UtcNow None
+            makeEntry 1 10 "text" [] [] DateTimeOffset.UtcNow DateTimeOffset.UtcNow
 
         let env =
             TestEnv(
@@ -643,13 +643,13 @@ let ``updates entry with definitions only``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "word" [] [] now None
+            makeEntry 1 10 "word" [] [] now now
 
         let definition =
             makeDefinition 10 "definition" DefinitionSource.Manual 0 []
 
         let updatedEntry =
-            makeEntry 1 10 "word" [ definition ] [] now (Some now)
+            makeEntry 1 10 "word" [ definition ] [] now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -709,13 +709,13 @@ let ``updates entry with translations only``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "word" [] [] now None
+            makeEntry 1 10 "word" [] [] now now
 
         let translation =
             makeTranslation 20 "translation" TranslationSource.Manual 0 []
 
         let updatedEntry =
-            makeEntry 1 10 "word" [] [ translation ] now (Some now)
+            makeEntry 1 10 "word" [] [ translation ] now now
 
         let getEntryByIdCallCount = ref 0
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
@@ -76,11 +76,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
+    let timestamp = DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = DateTimeOffset.UnixEpoch
-      UpdatedAt = DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
@@ -79,8 +79,8 @@ let makeEntry id vocabularyId text =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = DateTimeOffset.UnixEpoch
+      UpdatedAt = DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 
@@ -110,7 +110,7 @@ let makeEntryWithContent id vocabularyId text createdAt definitions translations
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
       CreatedAt = createdAt
-      UpdatedAt = None
+      UpdatedAt = createdAt
       Definitions = definitions
       Translations = translations }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
@@ -52,11 +52,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
@@ -55,8 +55,8 @@ let makeEntry id vocabularyId text =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
@@ -43,8 +43,8 @@ let makeEntry id vocabularyId entryText =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = entryText
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
@@ -40,11 +40,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId entryText =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = entryText
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
@@ -41,11 +41,13 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
+    let timestamp = System.DateTimeOffset.UtcNow
+
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UnixEpoch
-      UpdatedAt = System.DateTimeOffset.UnixEpoch
+      CreatedAt = timestamp
+      UpdatedAt = timestamp
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
@@ -44,8 +44,8 @@ let makeEntry id vocabularyId text =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
-      CreatedAt = System.DateTimeOffset.UtcNow
-      UpdatedAt = None
+      CreatedAt = System.DateTimeOffset.UnixEpoch
+      UpdatedAt = System.DateTimeOffset.UnixEpoch
       Definitions = []
       Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
@@ -115,7 +115,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text createdAt (updatedAt: DateTimeOffset) =
+let makeEntry id vocabularyId text createdAt updatedAt =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
@@ -115,7 +115,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text createdAt updatedAt =
+let makeEntry id vocabularyId text createdAt (updatedAt: DateTimeOffset) =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
@@ -125,12 +125,14 @@ let makeEntry id vocabularyId text createdAt updatedAt =
       Translations = [] }
 
 let makeCollection id userId : Collection =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = SystemCollectionName
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId createdAt : Vocabulary =
     { Id = VocabularyId id
@@ -138,7 +140,7 @@ let makeVocabulary id collectionId createdAt : Vocabulary =
       Name = DefaultVocabularyName
       Description = None
       CreatedAt = createdAt
-      UpdatedAt = None }
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``moves entry when explicit target vocabulary is accessible``() =
@@ -146,10 +148,10 @@ let ``moves entry when explicit target vocabulary is accessible``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let movedEntry =
-            makeEntry 10 200 "hello" now (Some now)
+            makeEntry 10 200 "hello" now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -223,13 +225,13 @@ let ``moves entry to existing default vocabulary when target vocabulary id is No
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let existingDefaultVocabulary =
             makeVocabulary 300 20 now
 
         let movedEntry =
-            makeEntry 10 300 "hello" now (Some now)
+            makeEntry 10 300 "hello" now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -298,13 +300,13 @@ let ``creates default vocabulary when target vocabulary id is None and default c
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let existingDefaultCollection =
             makeCollection 55 1
 
         let movedEntry =
-            makeEntry 10 300 "hello" now (Some now)
+            makeEntry 10 300 "hello" now now
 
         let expectedVocabularyParams: CreateDefaultVocabularyParameters =
             { CollectionId = CollectionId 55
@@ -382,10 +384,10 @@ let ``creates default collection and vocabulary when target vocabulary id is Non
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let movedEntry =
-            makeEntry 10 300 "hello" now (Some now)
+            makeEntry 10 300 "hello" now now
 
         let expectedCollectionParams: CreateDefaultCollectionParameters =
             { UserId = UserId 1
@@ -542,8 +544,7 @@ let ``returns EntryNotFound when entry belongs to different vocabulary``() =
     task {
         let now = DateTimeOffset.UtcNow
 
-        let entry =
-            makeEntry 10 999 "hello" now None
+        let entry = makeEntry 10 999 "hello" now now
 
         let env =
             TestEnv(
@@ -583,7 +584,7 @@ let ``returns VocabularyNotFoundOrAccessDenied when explicit target vocabulary a
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let env =
             TestEnv(
@@ -630,7 +631,7 @@ let ``throws when post-move entry fetch returns None``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "hello" now None
+            makeEntry 10 100 "hello" now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -675,10 +676,10 @@ let ``move succeeds without duplicate checks in explicit target vocabulary``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 10 100 "duplicate-text" now None
+            makeEntry 10 100 "duplicate-text" now now
 
         let movedEntry =
-            makeEntry 10 200 "duplicate-text" now (Some now)
+            makeEntry 10 200 "duplicate-text" now now
 
         let getEntryByIdCallCount = ref 0
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
@@ -116,7 +116,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text definitions translations createdAt (updatedAt: DateTimeOffset) =
+let makeEntry id vocabularyId text definitions translations createdAt updatedAt =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
@@ -116,7 +116,7 @@ type TestEnv
     interface ITransactional<TestEnv> with
         member this.RunInTransaction(operation) = operation this
 
-let makeEntry id vocabularyId text definitions translations createdAt updatedAt =
+let makeEntry id vocabularyId text definitions translations createdAt (updatedAt: DateTimeOffset) =
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
       EntryText = text
@@ -162,7 +162,7 @@ let ``updates entry with new definitions and translations``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "old" [] [] now None
+            makeEntry 1 10 "old" [] [] now now
 
         let example =
             makeExample 1 "example" ExampleSource.Custom
@@ -174,7 +174,7 @@ let ``updates entry with new definitions and translations``() =
             makeTranslation 20 "translation" TranslationSource.Manual 0 [ example ]
 
         let updatedEntry =
-            makeEntry 1 10 "new" [ definition ] [ translation ] now (Some now)
+            makeEntry 1 10 "new" [ definition ] [ translation ] now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -370,7 +370,7 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when entry belongs to different vocabulary``() =
     task {
         let entry =
-            makeEntry 1 99 "text" [] [] DateTimeOffset.UtcNow None
+            makeEntry 1 99 "text" [] [] DateTimeOffset.UtcNow DateTimeOffset.UtcNow
 
         let env =
             TestEnv(
@@ -702,13 +702,13 @@ let ``updates entry with definitions only``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "word" [] [] now None
+            makeEntry 1 10 "word" [] [] now now
 
         let definition =
             makeDefinition 10 "definition" DefinitionSource.Manual 0 []
 
         let updatedEntry =
-            makeEntry 1 10 "word" [ definition ] [] now (Some now)
+            makeEntry 1 10 "word" [ definition ] [] now now
 
         let getEntryByIdCallCount = ref 0
 
@@ -769,13 +769,13 @@ let ``updates entry with translations only``() =
         let now = DateTimeOffset.UtcNow
 
         let existingEntry =
-            makeEntry 1 10 "word" [] [] now None
+            makeEntry 1 10 "word" [] [] now now
 
         let translation =
             makeTranslation 20 "translation" TranslationSource.Manual 0 []
 
         let updatedEntry =
-            makeEntry 1 10 "word" [] [ translation ] now (Some now)
+            makeEntry 1 10 "word" [] [ translation ] now now
 
         let getEntryByIdCallCount = ref 0
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/GetOrCreateDefaultVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/GetOrCreateDefaultVocabularyTests.fs
@@ -62,12 +62,14 @@ type TestEnv
             createDefaultCollection parameters
 
 let makeCollection id userId : Collection =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = SystemCollectionName
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId createdAt : Vocabulary =
     { Id = VocabularyId id
@@ -75,7 +77,7 @@ let makeVocabulary id collectionId createdAt : Vocabulary =
       Name = DefaultVocabularyName
       Description = None
       CreatedAt = createdAt
-      UpdatedAt = None }
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``returns existing default vocabulary id when it exists``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/CreateTests.fs
@@ -53,12 +53,14 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name description createdAt =
     { Id = VocabularyId id
@@ -66,7 +68,7 @@ let makeVocabulary id collectionId name description createdAt =
       Name = name
       Description = description
       CreatedAt = createdAt
-      UpdatedAt = None }
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``creates vocabulary with valid name``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/DeleteTests.fs
@@ -53,20 +53,24 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``deletes vocabulary when collection owned by user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByCollectionIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByCollectionIdTests.fs
@@ -42,20 +42,24 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``returns vocabularies when collection owned by user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByIdTests.fs
@@ -41,20 +41,24 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``returns vocabulary when found and collection owned by user``() =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/MoveTests.fs
@@ -54,20 +54,24 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``moves vocabulary when both collections are owned and vocabulary is in source``() =
@@ -83,7 +87,7 @@ let ``moves vocabulary when both collections are owned and vocabulary is in sour
         let movedVocabulary =
             { existingVocabulary with
                 CollectionId = CollectionId 20
-                UpdatedAt = Some now }
+                UpdatedAt = now }
 
         let getVocabularyByIdCallCount = ref 0
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/UpdateTests.fs
@@ -53,20 +53,25 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
+    let createdAt = DateTimeOffset.UtcNow
+
     { Id = CollectionId id
       UserId = UserId userId
       Name = "Test Collection"
       Description = None
-      CreatedAt = DateTimeOffset.UtcNow
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name description =
+    let createdAt =
+        DateTimeOffset.UtcNow.AddDays(-1)
+
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
       Name = name
       Description = description
-      CreatedAt = DateTimeOffset.UtcNow.AddDays(-1)
-      UpdatedAt = None }
+      CreatedAt = createdAt
+      UpdatedAt = createdAt }
 
 [<Fact>]
 let ``updates vocabulary when collection owned by user``() =
@@ -126,7 +131,7 @@ let ``updates vocabulary when collection owned by user``() =
         | Ok updated ->
             Assert.Equal("New Name", updated.Name)
             Assert.Equal(Some "New Description", updated.Description)
-            Assert.Equal(Some now, updated.UpdatedAt)
+            Assert.Equal(now, updated.UpdatedAt)
         | Error e -> failwith $"Expected Ok, got Error: {e}"
 
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)

--- a/Wordfolio.Api/Wordfolio.Api.Domain/Collections/Operations.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Collections/Operations.fs
@@ -130,7 +130,7 @@ let update env (parameters: UpdateCollectionParameters) : Task<Result<Collection
                                 { collection with
                                     Name = trimmedName
                                     Description = parameters.Description
-                                    UpdatedAt = Some parameters.UpdatedAt }
+                                    UpdatedAt = parameters.UpdatedAt }
 
                             return Ok updated
                         else

--- a/Wordfolio.Api/Wordfolio.Api.Domain/CollectionsHierarchy/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/CollectionsHierarchy/Types.fs
@@ -9,7 +9,7 @@ type VocabularyWithEntryCount =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       EntryCount: int }
 
 type CollectionWithVocabularies =
@@ -17,7 +17,7 @@ type CollectionWithVocabularies =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       Vocabularies: VocabularyWithEntryCount list }
 
 type CollectionWithVocabularyCount =
@@ -25,7 +25,7 @@ type CollectionWithVocabularyCount =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       VocabularyCount: int }
 
 type CollectionsHierarchyResult =

--- a/Wordfolio.Api/Wordfolio.Api.Domain/Entries/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Entries/Types.fs
@@ -40,7 +40,7 @@ type Entry =
       VocabularyId: VocabularyId
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       Definitions: Definition list
       Translations: Translation list }
 

--- a/Wordfolio.Api/Wordfolio.Api.Domain/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Types.fs
@@ -50,7 +50,7 @@ type Collection =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type Vocabulary =
     { Id: VocabularyId
@@ -58,4 +58,4 @@ type Vocabulary =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }

--- a/Wordfolio.Api/Wordfolio.Api.Domain/Vocabularies/Operations.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Vocabularies/Operations.fs
@@ -195,7 +195,7 @@ let update env (parameters: UpdateVocabularyParameters) : Task<Result<Vocabulary
                                 { vocabulary with
                                     Name = trimmedName
                                     Description = parameters.Description
-                                    UpdatedAt = Some parameters.UpdatedAt }
+                                    UpdatedAt = parameters.UpdatedAt }
 
                             return Ok updated
                         else

--- a/Wordfolio.Api/Wordfolio.Api.Domain/Vocabularies/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Vocabularies/Types.fs
@@ -11,7 +11,7 @@ type VocabularyDetail =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type VocabularyNameValidationResult =
     | NameRequired

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/20260401001_MakeUpdatedAtNotNull.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/20260401001_MakeUpdatedAtNotNull.fs
@@ -1,0 +1,59 @@
+namespace Wordfolio.Api.Migrations
+
+open FluentMigrator
+
+open Constants
+
+[<Migration(20260401001L)>]
+type MakeUpdatedAtNotNull() =
+    inherit Migration()
+
+    override this.Up() =
+        base.Alter
+            .Table(CollectionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(CollectionsTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .NotNullable()
+        |> ignore
+
+        base.Alter
+            .Table(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(VocabulariesTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .NotNullable()
+        |> ignore
+
+        base.Alter
+            .Table(EntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(EntriesTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .NotNullable()
+        |> ignore
+
+    override this.Down() =
+        base.Alter
+            .Table(CollectionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(CollectionsTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .Nullable()
+        |> ignore
+
+        base.Alter
+            .Table(VocabulariesTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(VocabulariesTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .Nullable()
+        |> ignore
+
+        base.Alter
+            .Table(EntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .AlterColumn(EntriesTable.UpdatedAtColumn)
+            .AsDateTimeOffset()
+            .Nullable()
+        |> ignore

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="20251225005_AddExamplesCheckConstraint.fs" />
     <Compile Include="20260110001_AddSystemCollectionsAndDefaultVocabularies.fs" />
     <Compile Include="20260321001_AddCascadeDeleteToVocabulariesCollectionForeignKey.fs" />
+    <Compile Include="20260401001_MakeUpdatedAtNotNull.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio/Mapping.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio/Mapping.fs
@@ -18,7 +18,7 @@ and [<CLIMutable>] Collection =
       Name: string
       Description: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsSystem: bool
       User: User
       Vocabularies: ResizeArray<Vocabulary> }
@@ -29,7 +29,7 @@ and [<CLIMutable>] Vocabulary =
       Name: string
       Description: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       IsDefault: bool
       Collection: Collection
       Entries: ResizeArray<Entry> }
@@ -39,7 +39,7 @@ and [<CLIMutable>] Entry =
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: Nullable<DateTimeOffset>
+      UpdatedAt: DateTimeOffset
       Vocabulary: Vocabulary
       Definitions: ResizeArray<Definition>
       Translations: ResizeArray<Translation> }
@@ -139,7 +139,7 @@ type internal WordfolioTestDbContext(options: DbContextOptions<WordfolioTestDbCo
         collections.Property(_.CreatedAt).IsRequired()
         |> ignore
 
-        collections.Property(_.UpdatedAt).IsRequired(false)
+        collections.Property(_.UpdatedAt).IsRequired()
         |> ignore
 
         collections.Property(_.IsSystem).IsRequired()
@@ -168,7 +168,7 @@ type internal WordfolioTestDbContext(options: DbContextOptions<WordfolioTestDbCo
         vocabularies.Property(_.CreatedAt).IsRequired()
         |> ignore
 
-        vocabularies.Property(_.UpdatedAt).IsRequired(false)
+        vocabularies.Property(_.UpdatedAt).IsRequired()
         |> ignore
 
         vocabularies.Property(_.IsDefault).IsRequired()
@@ -199,7 +199,7 @@ type internal WordfolioTestDbContext(options: DbContextOptions<WordfolioTestDbCo
         entries.Property(_.CreatedAt).IsRequired()
         |> ignore
 
-        entries.Property(_.UpdatedAt).IsRequired(false)
+        entries.Property(_.UpdatedAt).IsRequired()
         |> ignore
 
         entries

--- a/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio/Seeder.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio/Seeder.fs
@@ -21,7 +21,7 @@ type Collection =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       IsSystem: bool }
 
 type Vocabulary =
@@ -30,7 +30,7 @@ type Vocabulary =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       IsDefault: bool }
 
 type Entry =
@@ -38,7 +38,7 @@ type Entry =
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type Definition =
     { Id: int
@@ -71,7 +71,7 @@ module Entities =
         (name: string)
         (description: string option)
         (createdAt: DateTimeOffset)
-        (updatedAt: DateTimeOffset option)
+        (updatedAt: DateTimeOffset)
         (isSystem: bool)
         : Mapping.Collection =
         let collection: Mapping.Collection =
@@ -80,7 +80,7 @@ module Entities =
               Name = name
               Description = description |> Option.toObj
               CreatedAt = createdAt
-              UpdatedAt = updatedAt |> Option.toNullable
+              UpdatedAt = updatedAt
               IsSystem = isSystem
               User = user
               Vocabularies = ResizeArray() }
@@ -93,7 +93,7 @@ module Entities =
         (name: string)
         (description: string option)
         (createdAt: DateTimeOffset)
-        (updatedAt: DateTimeOffset option)
+        (updatedAt: DateTimeOffset)
         (isDefault: bool)
         : Mapping.Vocabulary =
         let vocabulary: Mapping.Vocabulary =
@@ -102,7 +102,7 @@ module Entities =
               Name = name
               Description = description |> Option.toObj
               CreatedAt = createdAt
-              UpdatedAt = updatedAt |> Option.toNullable
+              UpdatedAt = updatedAt
               IsDefault = isDefault
               Collection = collection
               Entries = ResizeArray() }
@@ -114,14 +114,14 @@ module Entities =
         (vocabulary: Mapping.Vocabulary)
         (entryText: string)
         (createdAt: DateTimeOffset)
-        (updatedAt: DateTimeOffset option)
+        (updatedAt: DateTimeOffset)
         : Mapping.Entry =
         let entry: Mapping.Entry =
             { Id = 0
               VocabularyId = vocabulary.Id
               EntryText = entryText
               CreatedAt = createdAt
-              UpdatedAt = updatedAt |> Option.toNullable
+              UpdatedAt = updatedAt
               Vocabulary = vocabulary
               Definitions = ResizeArray()
               Translations = ResizeArray() }
@@ -215,7 +215,7 @@ module Seeder =
           Name = entity.Name
           Description = Option.ofObj entity.Description
           CreatedAt = entity.CreatedAt
-          UpdatedAt = Option.ofNullable entity.UpdatedAt
+          UpdatedAt = entity.UpdatedAt
           IsSystem = entity.IsSystem }
 
     let private toVocabulary(entity: Mapping.Vocabulary) : Vocabulary =
@@ -224,7 +224,7 @@ module Seeder =
           Name = entity.Name
           Description = Option.ofObj entity.Description
           CreatedAt = entity.CreatedAt
-          UpdatedAt = Option.ofNullable entity.UpdatedAt
+          UpdatedAt = entity.UpdatedAt
           IsDefault = entity.IsDefault }
 
     let private toEntry(entity: Mapping.Entry) : Entry =
@@ -232,7 +232,7 @@ module Seeder =
           VocabularyId = entity.VocabularyId
           EntryText = entity.EntryText
           CreatedAt = entity.CreatedAt
-          UpdatedAt = Option.ofNullable entity.UpdatedAt }
+          UpdatedAt = entity.UpdatedAt }
 
     let private toDefinition(entity: Mapping.Definition) : Definition =
         { Id = entity.Id

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
@@ -47,12 +47,16 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdCollectionId = result.Id
 
+            let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder
+
+            let createdAt = databaseState.Head.CreatedAt
+
             let expectedResult: CollectionResponse =
                 { Id = createdCollectionId
                   Name = "My Collection"
                   Description = Some "A test collection"
-                  CreatedAt = result.CreatedAt
-                  UpdatedAt = result.CreatedAt }
+                  CreatedAt = createdAt
+                  UpdatedAt = createdAt }
 
             Assert.Equal(expectedResult, result)
 
@@ -61,11 +65,9 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                     UserId = 100
                     Name = "My Collection"
                     Description = Some "A test collection"
-                    CreatedAt = result.CreatedAt
-                    UpdatedAt = result.CreatedAt
+                    CreatedAt = createdAt
+                    UpdatedAt = createdAt
                     IsSystem = false } ]
-
-            let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder
 
             Assert.Equal<Collection list>(expectedDatabaseState, databaseState)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
@@ -52,7 +52,7 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "My Collection"
                   Description = Some "A test collection"
                   CreatedAt = result.CreatedAt
-                  UpdatedAt = None }
+                  UpdatedAt = result.CreatedAt }
 
             Assert.Equal(expectedResult, result)
 
@@ -62,7 +62,7 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "My Collection"
                     Description = Some "A test collection"
                     CreatedAt = result.CreatedAt
-                    UpdatedAt = None
+                    UpdatedAt = result.CreatedAt
                     IsSystem = false } ]
 
             let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
@@ -47,26 +47,24 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdCollectionId = result.Id
 
-            let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder
-
-            let createdAt = databaseState.Head.CreatedAt
-
             let expectedResult: CollectionResponse =
                 { Id = createdCollectionId
                   Name = "My Collection"
                   Description = Some "A test collection"
-                  CreatedAt = createdAt
-                  UpdatedAt = createdAt }
+                  CreatedAt = result.CreatedAt
+                  UpdatedAt = result.CreatedAt }
 
             Assert.Equal(expectedResult, result)
+
+            let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder
 
             let expectedDatabaseState: Wordfolio.Collection list =
                 [ { Id = createdCollectionId
                     UserId = 100
                     Name = "My Collection"
                     Description = Some "A test collection"
-                    CreatedAt = createdAt
-                    UpdatedAt = createdAt
+                    CreatedAt = result.CreatedAt
+                    UpdatedAt = result.CreatedAt
                     IsSystem = false } ]
 
             Assert.Equal<Collection list>(expectedDatabaseState, databaseState)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
@@ -65,8 +65,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 106
                   Name = "Untouched Collection"
                   Description = Some "Untouched Description"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.UpdatedAt
+                  CreatedAt = untouchedCollection.CreatedAt
+                  UpdatedAt = untouchedCollection.CreatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -141,8 +141,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 112
                   Name = "Untouched Collection"
                   Description = Some "Untouched Description"
-                  CreatedAt = actualCollection.CreatedAt
-                  UpdatedAt = actualCollection.UpdatedAt
+                  CreatedAt = untouchedCollection.CreatedAt
+                  UpdatedAt = untouchedCollection.CreatedAt
                   IsSystem = false }
 
             Assert.Equal(expectedCollection, actualCollection)
@@ -159,8 +159,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   CollectionId = untouchedCollection.Id
                   Name = "Untouched Vocabulary"
                   Description = None
-                  CreatedAt = actualVocabulary.CreatedAt
-                  UpdatedAt = actualVocabulary.UpdatedAt
+                  CreatedAt = untouchedVocabulary.CreatedAt
+                  UpdatedAt = untouchedVocabulary.CreatedAt
                   IsDefault = false }
 
             Assert.Equal(expectedVocabulary, actualVocabulary)
@@ -176,8 +176,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Id = untouchedEntry.Id
                   VocabularyId = untouchedVocabulary.Id
                   EntryText = "untouched word"
-                  CreatedAt = actualEntry.CreatedAt
-                  UpdatedAt = actualEntry.UpdatedAt }
+                  CreatedAt = untouchedEntry.CreatedAt
+                  UpdatedAt = untouchedEntry.CreatedAt }
 
             Assert.Equal(expectedEntry, actualEntry)
         }
@@ -245,8 +245,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 109
                   Name = "Protected Collection"
                   Description = Some "Protected Description"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.UpdatedAt
+                  CreatedAt = collection.CreatedAt
+                  UpdatedAt = collection.CreatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -314,8 +314,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 110
                   Name = "Owner Collection"
                   Description = Some "Owner Description"
-                  CreatedAt = actualOwnerCollection.CreatedAt
-                  UpdatedAt = actualOwnerCollection.UpdatedAt
+                  CreatedAt = ownerCollection.CreatedAt
+                  UpdatedAt = ownerCollection.CreatedAt
                   IsSystem = false }
 
             let expectedRequesterCollection: Wordfolio.Collection =
@@ -323,8 +323,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 111
                   Name = "Requester Collection"
                   Description = Some "Requester Description"
-                  CreatedAt = actualRequesterCollection.CreatedAt
-                  UpdatedAt = actualRequesterCollection.UpdatedAt
+                  CreatedAt = requesterCollection.CreatedAt
+                  UpdatedAt = requesterCollection.CreatedAt
                   IsSystem = false }
 
             Assert.Equal(expectedOwnerCollection, actualOwnerCollection)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
@@ -26,15 +26,18 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let untouchedCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Untouched Collection"
                     (Some "Untouched Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -80,28 +83,35 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(112, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Collection with content" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection with content" None createdAt createdAt false
 
             let untouchedCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Untouched Collection"
                     (Some "Untouched Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary" None createdAt createdAt false
 
             let untouchedVocabulary =
-                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "word" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "word" createdAt createdAt
 
             let untouchedEntry =
-                Entities.makeEntry untouchedVocabulary "untouched word" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry untouchedVocabulary "untouched word" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -205,12 +215,14 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
             let collection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Protected Collection"
                     (Some "Protected Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -254,21 +266,25 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(111, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let requesterCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
@@ -25,19 +25,19 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             let untouchedCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeCollection
                     wordfolioUser
                     "Untouched Collection"
                     (Some "Untouched Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             do!
@@ -66,7 +66,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Untouched Collection"
                   Description = Some "Untouched Description"
                   CreatedAt = untouchedCollection.CreatedAt
-                  UpdatedAt = untouchedCollection.CreatedAt
+                  UpdatedAt = untouchedCollection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -82,36 +82,32 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(112, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection with content" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection with content" None timestamp timestamp false
 
             let untouchedCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeCollection
                     wordfolioUser
                     "Untouched Collection"
                     (Some "Untouched Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary" None timestamp timestamp false
 
             let untouchedVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary untouchedCollection "Untouched Vocabulary" None timestamp timestamp false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "word" createdAt createdAt
+                Entities.makeEntry vocabulary "word" timestamp timestamp
 
             let untouchedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry untouchedVocabulary "untouched word" createdAt createdAt
+                Entities.makeEntry untouchedVocabulary "untouched word" timestamp timestamp
 
             do!
                 fixture.WordfolioSeeder
@@ -142,7 +138,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Untouched Collection"
                   Description = Some "Untouched Description"
                   CreatedAt = untouchedCollection.CreatedAt
-                  UpdatedAt = untouchedCollection.CreatedAt
+                  UpdatedAt = untouchedCollection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expectedCollection, actualCollection)
@@ -160,7 +156,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Untouched Vocabulary"
                   Description = None
                   CreatedAt = untouchedVocabulary.CreatedAt
-                  UpdatedAt = untouchedVocabulary.CreatedAt
+                  UpdatedAt = untouchedVocabulary.UpdatedAt
                   IsDefault = false }
 
             Assert.Equal(expectedVocabulary, actualVocabulary)
@@ -177,7 +173,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = untouchedVocabulary.Id
                   EntryText = "untouched word"
                   CreatedAt = untouchedEntry.CreatedAt
-                  UpdatedAt = untouchedEntry.CreatedAt }
+                  UpdatedAt = untouchedEntry.UpdatedAt }
 
             Assert.Equal(expectedEntry, actualEntry)
         }
@@ -215,7 +211,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
+                let createdAt =
+                    DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
                 Entities.makeCollection
                     wordfolioUser
@@ -246,7 +243,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Protected Collection"
                   Description = Some "Protected Description"
                   CreatedAt = collection.CreatedAt
-                  UpdatedAt = collection.CreatedAt
+                  UpdatedAt = collection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -265,26 +262,25 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(111, "requester@example.com", "P@ssw0rd!")
 
-            let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
+            let ownerCollection =
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             do!
@@ -315,7 +311,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Owner Collection"
                   Description = Some "Owner Description"
                   CreatedAt = ownerCollection.CreatedAt
-                  UpdatedAt = ownerCollection.CreatedAt
+                  UpdatedAt = ownerCollection.UpdatedAt
                   IsSystem = false }
 
             let expectedRequesterCollection: Wordfolio.Collection =
@@ -324,7 +320,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Requester Collection"
                   Description = Some "Requester Description"
                   CreatedAt = requesterCollection.CreatedAt
-                  UpdatedAt = requesterCollection.CreatedAt
+                  UpdatedAt = requesterCollection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expectedOwnerCollection, actualOwnerCollection)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
@@ -28,7 +28,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
+                let createdAt =
+                    DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
                 Entities.makeCollection
                     wordfolioUser
@@ -58,7 +59,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Test Collection"
                   Description = Some "Test Description"
                   CreatedAt = collection.CreatedAt
-                  UpdatedAt = collection.CreatedAt }
+                  UpdatedAt = collection.UpdatedAt }
 
             Assert.Equal(expected, actual)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
@@ -28,12 +28,14 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
             let collection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Test Collection"
                     (Some "Test Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -56,7 +58,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Test Collection"
                   Description = Some "Test Description"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None }
+                  UpdatedAt = actual.CreatedAt }
 
             Assert.Equal(expected, actual)
         }
@@ -97,12 +99,14 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(106, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
@@ -57,8 +57,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
                 { Id = collection.Id
                   Name = "Test Collection"
                   Description = Some "Test Description"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.CreatedAt }
+                  CreatedAt = collection.CreatedAt
+                  UpdatedAt = collection.CreatedAt }
 
             Assert.Equal(expected, actual)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
@@ -30,21 +30,25 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
             let! _, secondWordfolioUser = factory.CreateUserAsync(101, "user2@example.com", "P@ssw0rd!")
 
             let firstUserCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     firstWordfolioUser
                     "First User Collection"
                     (Some "Owned by first user")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let secondUserCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     secondWordfolioUser
                     "Second User Collection"
                     (Some "Owned by second user")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -67,7 +71,7 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "First User Collection"
                     Description = Some "Owned by first user"
                     CreatedAt = actualCollections.Head.CreatedAt
-                    UpdatedAt = None } ]
+                    UpdatedAt = actualCollections.Head.CreatedAt } ]
 
             Assert.Equal<CollectionResponse list>(expectedCollections, actualCollections)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
@@ -29,26 +29,25 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, secondWordfolioUser = factory.CreateUserAsync(101, "user2@example.com", "P@ssw0rd!")
 
-            let firstUserCollection =
-                let createdAt = DateTimeOffset.UtcNow
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
+            let firstUserCollection =
                 Entities.makeCollection
                     firstWordfolioUser
                     "First User Collection"
                     (Some "Owned by first user")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             let secondUserCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeCollection
                     secondWordfolioUser
                     "Second User Collection"
                     (Some "Owned by second user")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             do!
@@ -71,7 +70,7 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "First User Collection"
                     Description = Some "Owned by first user"
                     CreatedAt = firstUserCollection.CreatedAt
-                    UpdatedAt = firstUserCollection.CreatedAt } ]
+                    UpdatedAt = firstUserCollection.UpdatedAt } ]
 
             Assert.Equal<CollectionResponse list>(expectedCollections, actualCollections)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
@@ -70,8 +70,8 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
                 [ { Id = firstUserCollection.Id
                     Name = "First User Collection"
                     Description = Some "Owned by first user"
-                    CreatedAt = actualCollections.Head.CreatedAt
-                    UpdatedAt = actualCollections.Head.CreatedAt } ]
+                    CreatedAt = firstUserCollection.CreatedAt
+                    UpdatedAt = firstUserCollection.CreatedAt } ]
 
             Assert.Equal<CollectionResponse list>(expectedCollections, actualCollections)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
@@ -27,27 +27,13 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(105, "user@example.com", "P@ssw0rd!")
 
-            let collection =
-                let createdAt = DateTimeOffset.UtcNow
+            let now = DateTimeOffset.UtcNow
 
-                Entities.makeCollection
-                    wordfolioUser
-                    "Original Name"
-                    (Some "Original Description")
-                    createdAt
-                    createdAt
-                    false
+            let collection =
+                Entities.makeCollection wordfolioUser "Original Name" (Some "Original Description") now now false
 
             let untouchedCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
-                Entities.makeCollection
-                    wordfolioUser
-                    "Untouched Name"
-                    (Some "Untouched Description")
-                    createdAt
-                    createdAt
-                    false
+                Entities.makeCollection wordfolioUser "Untouched Name" (Some "Untouched Description") now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -134,9 +120,11 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Original Name" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Original Name" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -162,8 +150,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 106
                   Name = "Original Name"
                   Description = None
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.UpdatedAt
+                  CreatedAt = collection.CreatedAt
+                  UpdatedAt = collection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)
@@ -182,26 +170,18 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(108, "requester@example.com", "P@ssw0rd!")
 
-            let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
+            let now = DateTimeOffset.UtcNow
 
-                Entities.makeCollection
-                    ownerWordfolioUser
-                    "Owner Collection"
-                    (Some "Owner Description")
-                    createdAt
-                    createdAt
-                    false
+            let ownerCollection =
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" (Some "Owner Description") now now false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    createdAt
-                    createdAt
+                    now
+                    now
                     false
 
             do!
@@ -262,15 +242,16 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
-            let collection =
-                let createdAt = DateTimeOffset.UtcNow
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
+            let collection =
                 Entities.makeCollection
                     wordfolioUser
                     "Original Name"
                     (Some "Original Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             do!
@@ -297,8 +278,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                   UserId = 109
                   Name = "Original Name"
                   Description = Some "Original Description"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.UpdatedAt
+                  CreatedAt = collection.CreatedAt
+                  UpdatedAt = collection.UpdatedAt
                   IsSystem = false }
 
             Assert.Equal(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
@@ -28,21 +28,25 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(105, "user@example.com", "P@ssw0rd!")
 
             let collection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Original Name"
                     (Some "Original Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let untouchedCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Untouched Name"
                     (Some "Untouched Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -131,7 +135,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Original Name" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Original Name" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -178,21 +183,25 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(108, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let requesterCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -254,12 +263,14 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
             let collection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     wordfolioUser
                     "Original Name"
                     (Some "Original Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
@@ -27,33 +27,29 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection 1" (Some "Description 1") createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection 1" (Some "Description 1") now now false
 
             let collection2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection 2" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection 2" None now now false
 
             let vocabulary1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection1 "Vocabulary 1" (Some "Vocab description") createdAt createdAt false
+                Entities.makeVocabulary collection1 "Vocabulary 1" (Some "Vocab description") now now false
 
             let vocabulary2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection1 "Vocabulary 2" None createdAt createdAt false
+                Entities.makeVocabulary collection1 "Vocabulary 2" None now now false
 
             let entry1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary1 "entry1" createdAt createdAt
+                Entities.makeEntry vocabulary1 "entry1" now now
 
             let entry2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary1 "entry2" createdAt createdAt
+                Entities.makeEntry vocabulary1 "entry2" now now
 
             let entry3 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary2 "entry3" createdAt createdAt
+                Entities.makeEntry vocabulary2 "entry3" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -124,57 +120,48 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, otherWordfolioUser = factory.CreateUserAsync(307, "other@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
 
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    createdAt
-                    createdAt
+                    now
+                    now
                     false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
 
                 Entities.makeVocabulary
                     requesterCollection
                     "Requester Vocabulary"
                     (Some "Requester Vocab Description")
-                    createdAt
-                    createdAt
+                    now
+                    now
                     false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester-entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester-entry" now now
 
             let otherCollection =
-                let createdAt = DateTimeOffset.UtcNow
 
-                Entities.makeCollection
-                    otherWordfolioUser
-                    "Other Collection"
-                    (Some "Other Description")
-                    createdAt
-                    createdAt
-                    false
+                Entities.makeCollection otherWordfolioUser "Other Collection" (Some "Other Description") now now false
 
             let otherVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
 
                 Entities.makeVocabulary
                     otherCollection
                     "Other Vocabulary"
                     (Some "Other Vocab Description")
-                    createdAt
-                    createdAt
+                    now
+                    now
                     false
 
             let otherEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry otherVocabulary "other-entry" createdAt createdAt
+                Entities.makeEntry otherVocabulary "other-entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -228,13 +215,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "System Collection" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "System Collection" None now now true
 
             do!
                 fixture.WordfolioSeeder
@@ -277,17 +264,16 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Regular Vocabulary" None now now false
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Default Vocabulary" None createdAt createdAt true
+                Entities.makeVocabulary collection "Default Vocabulary" None now now true
 
             do!
                 fixture.WordfolioSeeder
@@ -368,21 +354,20 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "My Words" (Some "Default vocab") createdAt createdAt true
+                Entities.makeVocabulary systemCollection "My Words" (Some "Default vocab") now now true
 
             let entry1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry defaultVocabulary "word1" createdAt createdAt
+                Entities.makeEntry defaultVocabulary "word1" now now
 
             let entry2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry defaultVocabulary "word2" createdAt createdAt
+                Entities.makeEntry defaultVocabulary "word2" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -408,8 +393,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                         { Id = defaultVocabulary.Id
                           Name = "My Words"
                           Description = Some "Default vocab"
-                          CreatedAt = actual.DefaultVocabulary.Value.CreatedAt
-                          UpdatedAt = actual.DefaultVocabulary.Value.CreatedAt
+                          CreatedAt = defaultVocabulary.CreatedAt
+                          UpdatedAt = defaultVocabulary.UpdatedAt
                           EntryCount = 2 } }
 
             Assert.Equal(expected, actual)
@@ -425,13 +410,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(305, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "My Words" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "My Words" None now now true
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
@@ -28,37 +28,32 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
             let collection1 =
-                Entities.makeCollection
-                    wordfolioUser
-                    "Collection 1"
-                    (Some "Description 1")
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection 1" (Some "Description 1") createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection wordfolioUser "Collection 2" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection 2" None createdAt createdAt false
 
             let vocabulary1 =
-                Entities.makeVocabulary
-                    collection1
-                    "Vocabulary 1"
-                    (Some "Vocab description")
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection1 "Vocabulary 1" (Some "Vocab description") createdAt createdAt false
 
             let vocabulary2 =
-                Entities.makeVocabulary collection1 "Vocabulary 2" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection1 "Vocabulary 2" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocabulary1 "entry1" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary1 "entry1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocabulary1 "entry2" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary1 "entry2" createdAt createdAt
 
             let entry3 =
-                Entities.makeEntry vocabulary2 "entry3" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary2 "entry3" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -91,25 +86,25 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                         Name = "Collection 1"
                         Description = Some "Description 1"
                         CreatedAt = actualCollection1.CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actualCollection1.CreatedAt
                         Vocabularies =
                           [ { Id = vocabulary1.Id
                               Name = "Vocabulary 1"
                               Description = Some "Vocab description"
                               CreatedAt = actualCollection1.Vocabularies[0].CreatedAt
-                              UpdatedAt = None
+                              UpdatedAt = actualCollection1.Vocabularies[0].CreatedAt
                               EntryCount = 2 }
                             { Id = vocabulary2.Id
                               Name = "Vocabulary 2"
                               Description = None
                               CreatedAt = actualCollection1.Vocabularies[1].CreatedAt
-                              UpdatedAt = None
+                              UpdatedAt = actualCollection1.Vocabularies[1].CreatedAt
                               EntryCount = 1 } ] }
                       { Id = collection2.Id
                         Name = "Collection 2"
                         Description = None
                         CreatedAt = actualCollection2.CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actualCollection2.CreatedAt
                         Vocabularies = [] } ]
                   DefaultVocabulary = None }
 
@@ -130,46 +125,56 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! _, otherWordfolioUser = factory.CreateUserAsync(307, "other@example.com", "P@ssw0rd!")
 
             let requesterCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     requesterWordfolioUser
                     "Requester Collection"
                     (Some "Requester Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let requesterVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     requesterCollection
                     "Requester Vocabulary"
                     (Some "Requester Vocab Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester-entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester-entry" createdAt createdAt
 
             let otherCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     otherWordfolioUser
                     "Other Collection"
                     (Some "Other Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let otherVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     otherCollection
                     "Other Vocabulary"
                     (Some "Other Vocab Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let otherEntry =
-                Entities.makeEntry otherVocabulary "other-entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry otherVocabulary "other-entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -200,13 +205,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                         Name = "Requester Collection"
                         Description = Some "Requester Description"
                         CreatedAt = actualCollection.CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actualCollection.CreatedAt
                         Vocabularies =
                           [ { Id = requesterVocabulary.Id
                               Name = "Requester Vocabulary"
                               Description = Some "Requester Vocab Description"
                               CreatedAt = actualVocabulary.CreatedAt
-                              UpdatedAt = None
+                              UpdatedAt = actualVocabulary.CreatedAt
                               EntryCount = 1 } ] } ]
                   DefaultVocabulary = None }
 
@@ -224,10 +229,12 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "System Collection" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "System Collection" None createdAt createdAt true
 
             do!
                 fixture.WordfolioSeeder
@@ -253,7 +260,7 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                         Name = "Regular Collection"
                         Description = None
                         CreatedAt = actualCollection.CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actualCollection.CreatedAt
                         Vocabularies = [] } ]
                   DefaultVocabulary = None }
 
@@ -271,13 +278,16 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Regular Vocabulary" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default Vocabulary" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Default Vocabulary" None createdAt createdAt true
 
             do!
                 fixture.WordfolioSeeder
@@ -304,13 +314,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                         Name = "Test Collection"
                         Description = None
                         CreatedAt = actualCollection.CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actualCollection.CreatedAt
                         Vocabularies =
                           [ { Id = regularVocabulary.Id
                               Name = "Regular Vocabulary"
                               Description = None
                               CreatedAt = actualCollection.Vocabularies[0].CreatedAt
-                              UpdatedAt = None
+                              UpdatedAt = actualCollection.Vocabularies[0].CreatedAt
                               EntryCount = 0 } ] } ]
                   DefaultVocabulary = None }
 
@@ -359,22 +369,20 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary
-                    systemCollection
-                    "My Words"
-                    (Some "Default vocab")
-                    DateTimeOffset.UtcNow
-                    None
-                    true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "My Words" (Some "Default vocab") createdAt createdAt true
 
             let entry1 =
-                Entities.makeEntry defaultVocabulary "word1" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry defaultVocabulary "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry defaultVocabulary "word2" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry defaultVocabulary "word2" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -401,7 +409,7 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                           Name = "My Words"
                           Description = Some "Default vocab"
                           CreatedAt = actual.DefaultVocabulary.Value.CreatedAt
-                          UpdatedAt = None
+                          UpdatedAt = actual.DefaultVocabulary.Value.CreatedAt
                           EntryCount = 2 } }
 
             Assert.Equal(expected, actual)
@@ -418,10 +426,12 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(305, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "My Words" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "My Words" None createdAt createdAt true
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsListTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsListTests.fs
@@ -37,13 +37,13 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 4, 0, 0, 0, TimeSpan.Zero)
 
             let collection1 =
-                Entities.makeCollection wordfolioUser "Biology" (Some "School words") createdAt (Some updatedAt1) false
+                Entities.makeCollection wordfolioUser "Biology" (Some "School words") createdAt updatedAt1 false
 
             let collection2 =
-                Entities.makeCollection wordfolioUser "Travel" (Some "Bio terms") createdAt (Some updatedAt2) false
+                Entities.makeCollection wordfolioUser "Travel" (Some "Bio terms") createdAt updatedAt2 false
 
             let collection3 =
-                Entities.makeCollection wordfolioUser "Sports" None createdAt None false
+                Entities.makeCollection wordfolioUser "Sports" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -66,19 +66,19 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "Travel"
                     Description = Some "Bio terms"
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAt2
+                    UpdatedAt = updatedAt2
                     VocabularyCount = 0 }
                   { Id = collection1.Id
                     Name = "Biology"
                     Description = Some "School words"
                     CreatedAt = createdAt
-                    UpdatedAt = Some updatedAt1
+                    UpdatedAt = updatedAt1
                     VocabularyCount = 0 }
                   { Id = collection3.Id
                     Name = "Sports"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionWithVocabularyCountResponse list>(expected, actual)
@@ -100,10 +100,10 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let ownedCollection =
-                Entities.makeCollection wordfolioUser "Owned" None createdAt None false
+                Entities.makeCollection wordfolioUser "Owned" None createdAt createdAt false
 
             let otherCollection =
-                Entities.makeCollection otherUser "Other" None createdAt None false
+                Entities.makeCollection otherUser "Other" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -126,7 +126,7 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "Owned"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 0 } ]
 
             Assert.Equal<CollectionWithVocabularyCountResponse list>(expected, actual)
@@ -176,25 +176,25 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection =
-                Entities.makeCollection wordfolioUser "Regular" None createdAt None false
+                Entities.makeCollection wordfolioUser "Regular" None createdAt createdAt false
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "System" None createdAt None true
+                Entities.makeCollection wordfolioUser "System" None createdAt createdAt true
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular Vocab" None createdAt None false
+                Entities.makeVocabulary collection "Regular Vocab" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default Vocab" None createdAt None true
+                Entities.makeVocabulary collection "Default Vocab" None createdAt createdAt true
 
             let systemCollectionVocabulary =
-                Entities.makeVocabulary systemCollection "System Vocab" None createdAt None false
+                Entities.makeVocabulary systemCollection "System Vocab" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry regularVocabulary "word1" createdAt None
+                Entities.makeEntry regularVocabulary "word1" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry regularVocabulary "word2" createdAt None
+                Entities.makeEntry regularVocabulary "word2" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -218,7 +218,7 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     VocabularyCount = 1 } ]
 
             Assert.Equal<CollectionWithVocabularyCountResponse list>(expected, actual)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
@@ -31,16 +31,16 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection =
-                Entities.makeCollection wordfolioUser "Collection" (Some "Description") createdAt None false
+                Entities.makeCollection wordfolioUser "Collection" (Some "Description") createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary collection "Regular" None createdAt None false
+                Entities.makeVocabulary collection "Regular" None createdAt createdAt false
 
             let defaultVocabulary =
-                Entities.makeVocabulary collection "Default" None createdAt None true
+                Entities.makeVocabulary collection "Default" None createdAt createdAt true
 
             let entry =
-                Entities.makeEntry regularVocabulary "word" createdAt None
+                Entities.makeEntry regularVocabulary "word" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -68,7 +68,7 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
-                    UpdatedAt = None
+                    UpdatedAt = createdAt
                     EntryCount = 1 } ]
 
             Assert.Equal<VocabularyWithEntryCountResponse list>(expected, actual)
@@ -90,16 +90,16 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let otherUser = Entities.makeUser 314
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser "Requester Collection" None createdAt None false
+                Entities.makeCollection wordfolioUser "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt None false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let otherCollection =
-                Entities.makeCollection otherUser "Other Collection" None createdAt None false
+                Entities.makeCollection otherUser "Other Collection" None createdAt createdAt false
 
             let otherVocabulary =
-                Entities.makeVocabulary otherCollection "Other Vocabulary" None createdAt None false
+                Entities.makeVocabulary otherCollection "Other Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -135,10 +135,12 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(318, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "System Collection" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "System Collection" None createdAt createdAt true
 
             let vocabulary =
-                Entities.makeVocabulary collection "Vocab" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocab" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
@@ -67,7 +67,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabularies.[0].Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
 
@@ -105,10 +105,12 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(401, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             do!
                 fixture.WordfolioSeeder
@@ -148,7 +150,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
 
@@ -249,7 +251,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabularies.[0].Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 
@@ -510,13 +512,16 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(604, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             let existingEntry =
-                Entities.makeEntry defaultVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry defaultVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -553,13 +558,16 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(605, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             let existingEntry =
-                Entities.makeEntry defaultVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry defaultVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -600,7 +608,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
@@ -104,13 +104,13 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(401, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             do!
                 fixture.WordfolioSeeder
@@ -511,17 +511,16 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(604, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             let existingEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry defaultVocabulary "hello" createdAt createdAt
+                Entities.makeEntry defaultVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -557,17 +556,16 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(605, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             let existingEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry defaultVocabulary "hello" createdAt createdAt
+                Entities.makeEntry defaultVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
@@ -25,21 +25,19 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(706, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let unaffectedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "remain" createdAt createdAt
+                Entities.makeEntry vocabulary "remain" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -87,17 +85,16 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(707, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -161,29 +158,25 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(715, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(716, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -239,17 +232,16 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
@@ -26,16 +26,20 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(706, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let unaffectedEntry =
-                Entities.makeEntry vocabulary "remain" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "remain" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -84,13 +88,16 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(707, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -155,22 +162,28 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(716, "user2@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser1 "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -227,13 +240,16 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
@@ -28,13 +28,16 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(700, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -109,7 +112,7 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
@@ -27,17 +27,17 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(700, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition
@@ -111,8 +111,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
+                  UpdatedAt = entry.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftsTests.fs
@@ -47,10 +47,10 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection =
-                Entities.makeCollection wordfolioUser "Col" None createdAt None false
+                Entities.makeCollection wordfolioUser "Col" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "NotDefault" None createdAt None false
+                Entities.makeVocabulary collection "NotDefault" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -80,10 +80,10 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection =
-                Entities.makeCollection wordfolioUser "Col" None createdAt None false
+                Entities.makeCollection wordfolioUser "Col" None createdAt createdAt false
 
             let defaultVocab =
-                Entities.makeVocabulary collection "Drafts" (Some "My drafts") createdAt None true
+                Entities.makeVocabulary collection "Drafts" (Some "My drafts") createdAt createdAt true
 
             do!
                 fixture.WordfolioSeeder
@@ -107,7 +107,7 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Drafts"
                       Description = Some "My drafts"
                       CreatedAt = actual.Vocabulary.CreatedAt
-                      UpdatedAt = None }
+                      UpdatedAt = actual.Vocabulary.CreatedAt }
                   Entries = [] }
 
             Assert.Equal(expected, actual)
@@ -127,13 +127,13 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection =
-                Entities.makeCollection wordfolioUser "Col" None createdAt None false
+                Entities.makeCollection wordfolioUser "Col" None createdAt createdAt false
 
             let defaultVocab =
-                Entities.makeVocabulary collection "Drafts" None createdAt None true
+                Entities.makeVocabulary collection "Drafts" None createdAt createdAt true
 
             let entry =
-                Entities.makeEntry defaultVocab "ephemeral" createdAt None
+                Entities.makeEntry defaultVocab "ephemeral" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -181,13 +181,13 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Drafts"
                       Description = None
                       CreatedAt = actual.Vocabulary.CreatedAt
-                      UpdatedAt = None }
+                      UpdatedAt = actual.Vocabulary.CreatedAt }
                   Entries =
                     [ { Id = entry.Id
                         VocabularyId = defaultVocab.Id
                         EntryText = "ephemeral"
                         CreatedAt = actual.Entries.[0].CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actual.Entries.[0].CreatedAt
                         Definitions =
                           [ { Id = definition.Id
                               DefinitionText = "lasting for a short time"
@@ -223,22 +223,22 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
             let collection1 =
-                Entities.makeCollection wordfolioUser1 "Col1" None createdAt None false
+                Entities.makeCollection wordfolioUser1 "Col1" None createdAt createdAt false
 
             let collection2 =
-                Entities.makeCollection wordfolioUser2 "Col2" None createdAt None false
+                Entities.makeCollection wordfolioUser2 "Col2" None createdAt createdAt false
 
             let vocab1 =
-                Entities.makeVocabulary collection1 "Drafts1" None createdAt None true
+                Entities.makeVocabulary collection1 "Drafts1" None createdAt createdAt true
 
             let vocab2 =
-                Entities.makeVocabulary collection2 "Drafts2" None createdAt None true
+                Entities.makeVocabulary collection2 "Drafts2" None createdAt createdAt true
 
             let entry1 =
-                Entities.makeEntry vocab1 "myword" createdAt None
+                Entities.makeEntry vocab1 "myword" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocab2 "otherword" createdAt None
+                Entities.makeEntry vocab2 "otherword" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -259,13 +259,13 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Drafts1"
                       Description = None
                       CreatedAt = actual.Vocabulary.CreatedAt
-                      UpdatedAt = None }
+                      UpdatedAt = actual.Vocabulary.CreatedAt }
                   Entries =
                     [ { Id = entry1.Id
                         VocabularyId = vocab1.Id
                         EntryText = "myword"
                         CreatedAt = actual.Entries.[0].CreatedAt
-                        UpdatedAt = None
+                        UpdatedAt = actual.Entries.[0].CreatedAt
                         Definitions = []
                         Translations = [] } ] }
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
@@ -28,25 +28,23 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(709, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let targetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection "Target" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             let unaffectedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "stay" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "stay" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -71,11 +69,13 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! actual = response.Content.ReadFromJsonAsync<EntryResponse>()
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = targetVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -89,28 +89,24 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
                     { Id = entry.Id
                       VocabularyId = targetVocabulary.Id
                       EntryText = "hello"
-                      CreatedAt = actual.CreatedAt
+                      CreatedAt = entry.CreatedAt
                       UpdatedAt = actual.UpdatedAt }
 
             Assert.Equal(expectedMovedEntry, movedEntry)
 
             let! dbEntries = Seeder.getAllEntriesAsync fixture.WordfolioSeeder
 
-            let unaffectedEntryInDatabase =
-                dbEntries
-                |> List.find(fun currentEntry -> currentEntry.Id = unaffectedEntry.Id)
-
             let expectedDbEntries =
-                [ { unaffectedEntryInDatabase with
-                      Id = unaffectedEntry.Id
-                      VocabularyId = sourceVocabulary.Id
-                      EntryText = "stay" }
-                  { unaffectedEntryInDatabase with
-                      Id = entry.Id
-                      VocabularyId = targetVocabulary.Id
-                      EntryText = "hello"
-                      CreatedAt = actual.CreatedAt
-                      UpdatedAt = actual.UpdatedAt } ]
+                [ { Id = unaffectedEntry.Id
+                    VocabularyId = sourceVocabulary.Id
+                    EntryText = "stay"
+                    CreatedAt = unaffectedEntry.CreatedAt
+                    UpdatedAt = unaffectedEntry.UpdatedAt }
+                  { Id = entry.Id
+                    VocabularyId = targetVocabulary.Id
+                    EntryText = "hello"
+                    CreatedAt = entry.CreatedAt
+                    UpdatedAt = actual.UpdatedAt } ]
                 |> List.sortBy(fun currentEntry -> currentEntry.Id)
 
             let actualDbEntries =
@@ -130,21 +126,20 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let targetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection "Target" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -209,17 +204,17 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(711, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -250,37 +245,31 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(718, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(719, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Collection 1" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Collection 1" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection1 "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection1 "Source" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             let collection2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Collection 2" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Collection 2" None now now false
 
             let foreignTargetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection2 "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection2 "Target" None now now false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -337,25 +326,23 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(720, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
+                Entities.makeEntry regularVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -378,11 +365,13 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! actual = response.Content.ReadFromJsonAsync<EntryResponse>()
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = defaultVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
@@ -29,19 +29,24 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(709, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             let unaffectedEntry =
-                Entities.makeEntry sourceVocabulary "stay" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "stay" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -126,16 +131,20 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -201,13 +210,16 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(711, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -239,28 +251,36 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser2 = factory.CreateUserAsync(719, "user2@example.com", "P@ssw0rd!")
 
             let collection1 =
-                Entities.makeCollection wordfolioUser1 "Collection 1" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Collection 1" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection1 "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection1 "Source" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             let collection2 =
-                Entities.makeCollection wordfolioUser2 "Collection 2" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Collection 2" None createdAt createdAt false
 
             let foreignTargetVocabulary =
-                Entities.makeVocabulary collection2 "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection2 "Target" None createdAt createdAt false
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser1 "Requester Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -318,19 +338,24 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(720, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry regularVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
@@ -27,21 +27,20 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(702, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let untouchedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "untouched" createdAt createdAt
+                Entities.makeEntry vocabulary "untouched" now now
 
             let oldDefinition =
                 Entities.makeDefinition
@@ -145,11 +144,13 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   DisplayOrder = 0
                   Examples = [ expectedTranslationExample ] }
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello updated"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
@@ -241,21 +242,20 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(715, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let untouchedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "untouched" createdAt createdAt
+                Entities.makeEntry vocabulary "untouched" now now
 
             let definition =
                 Entities.makeDefinition
@@ -322,17 +322,17 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(703, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -384,17 +384,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(704, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -475,17 +474,17 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(712, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -522,11 +521,13 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   DisplayOrder = 0
                   Examples = [] }
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
@@ -571,17 +572,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(713, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(714, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
@@ -28,16 +28,20 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(702, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let untouchedEntry =
-                Entities.makeEntry vocabulary "untouched" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "untouched" createdAt createdAt
 
             let oldDefinition =
                 Entities.makeDefinition
@@ -238,16 +242,20 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(715, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let untouchedEntry =
-                Entities.makeEntry vocabulary "untouched" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "untouched" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -315,13 +323,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(703, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -374,13 +385,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(704, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -462,13 +476,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(712, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -555,13 +572,16 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(714, "user2@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser1 "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
@@ -28,13 +28,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -163,13 +163,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(320, "auth-required@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Auth Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Auth Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Auth Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Auth Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -219,13 +219,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -278,17 +278,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(322, "owner@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
 
             let ownerVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None now now false
 
             let ownerEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry ownerVocabulary "existing entry" createdAt createdAt
+                Entities.makeEntry ownerVocabulary "existing entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -346,13 +345,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -387,13 +386,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(303, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -443,17 +442,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let existingEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -492,17 +490,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(319, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let existingEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -612,13 +609,13 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -653,21 +650,19 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(517, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionA "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collectionA "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Vocabulary B" None now now false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
@@ -29,10 +29,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -99,7 +101,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 
@@ -162,10 +164,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(320, "auth-required@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Auth Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Auth Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Auth Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Auth Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -216,10 +220,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -273,13 +279,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, ownerWordfolioUser = factory.CreateUserAsync(322, "owner@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
 
             let ownerVocabulary =
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
 
             let ownerEntry =
-                Entities.makeEntry ownerVocabulary "existing entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry ownerVocabulary "existing entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -338,10 +347,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -377,10 +388,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(303, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -431,13 +444,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let existingEntry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -477,13 +493,16 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(319, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let existingEntry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -527,7 +546,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
 
@@ -594,10 +613,12 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -633,16 +654,20 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(517, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collectionA "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionA "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collectionB "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Vocabulary B" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
@@ -28,16 +28,20 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(402, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let unaffectedEntry =
-                Entities.makeEntry vocabulary "remain" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "remain" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -87,13 +91,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(403, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -160,22 +167,28 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(406, "user2@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser1 "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -233,13 +246,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(407, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -307,13 +323,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(510, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -341,16 +360,20 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(514, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collection "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collection "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabularyA "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabularyA "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -378,16 +401,20 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(521, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
@@ -27,21 +27,19 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(402, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let unaffectedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "remain" createdAt createdAt
+                Entities.makeEntry vocabulary "remain" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -90,17 +88,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(403, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -166,29 +163,25 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(405, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(406, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -245,17 +238,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(407, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition
@@ -322,17 +314,16 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(510, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -359,21 +350,19 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(514, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary B" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabularyA "hello" createdAt createdAt
+                Entities.makeEntry vocabularyA "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -400,21 +389,19 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(521, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
@@ -27,21 +27,19 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(308, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let entry2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "world" createdAt createdAt
+                Entities.makeEntry vocabulary "world" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -97,13 +95,13 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(309, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -184,25 +182,22 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, otherWordfolioUser = factory.CreateUserAsync(312, "other@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let otherCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection otherWordfolioUser "Other Collection" None createdAt createdAt false
+                Entities.makeCollection otherWordfolioUser "Other Collection" None now now false
 
             let otherVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary otherCollection "Other Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary otherCollection "Other Vocabulary" None now now false
 
             let otherEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry otherVocabulary "foreign-entry" createdAt createdAt
+                Entities.makeEntry otherVocabulary "foreign-entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -229,13 +224,13 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -261,21 +256,19 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(516, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionA "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collectionA "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Vocabulary B" None now now false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
@@ -28,16 +28,20 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(308, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry1 =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let entry2 =
-                Entities.makeEntry vocabulary "world" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "world" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -69,14 +73,14 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                     VocabularyId = vocabulary.Id
                     EntryText = "hello"
                     CreatedAt = actual.[0].CreatedAt
-                    UpdatedAt = None
+                    UpdatedAt = actual.[0].CreatedAt
                     Definitions = []
                     Translations = [] }
                   { Id = actual.[1].Id
                     VocabularyId = vocabulary.Id
                     EntryText = "world"
                     CreatedAt = actual.[1].CreatedAt
-                    UpdatedAt = None
+                    UpdatedAt = actual.[1].CreatedAt
                     Definitions = []
                     Translations = [] } ]
 
@@ -94,10 +98,12 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(309, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -179,25 +185,24 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! _, otherWordfolioUser = factory.CreateUserAsync(312, "other@example.com", "P@ssw0rd!")
 
             let requesterCollection =
-                Entities.makeCollection
-                    requesterWordfolioUser
-                    "Requester Collection"
-                    None
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let otherCollection =
-                Entities.makeCollection otherWordfolioUser "Other Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection otherWordfolioUser "Other Collection" None createdAt createdAt false
 
             let otherVocabulary =
-                Entities.makeVocabulary otherCollection "Other Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary otherCollection "Other Vocabulary" None createdAt createdAt false
 
             let otherEntry =
-                Entities.makeEntry otherVocabulary "foreign-entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry otherVocabulary "foreign-entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -225,10 +230,12 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -255,16 +262,20 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(516, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collectionA "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionA "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collectionB "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Vocabulary B" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
@@ -28,13 +28,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(306, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -110,7 +113,7 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = actual.CreatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 
@@ -156,13 +159,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(521, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
 
             let ownerVocabulary =
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
 
             let ownerEntry =
-                Entities.makeEntry ownerVocabulary "owner-entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry ownerVocabulary "owner-entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -208,13 +214,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -242,16 +251,20 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(512, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collection "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collection "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabularyA "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabularyA "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -279,13 +292,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(518, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -313,16 +329,20 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(519, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
@@ -27,17 +27,17 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(306, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition
@@ -112,8 +112,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
+                  UpdatedAt = entry.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
 
@@ -158,17 +158,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(521, "requester@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
 
             let ownerVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None now now false
 
             let ownerEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry ownerVocabulary "owner-entry" createdAt createdAt
+                Entities.makeEntry ownerVocabulary "owner-entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -213,17 +212,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -250,21 +248,19 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(512, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary B" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabularyA "hello" createdAt createdAt
+                Entities.makeEntry vocabularyA "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -291,17 +287,16 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(518, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -328,21 +323,19 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(519, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
@@ -31,19 +31,24 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(500, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             let unaffectedEntry =
-                Entities.makeEntry sourceVocabulary "stay" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "stay" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -129,16 +134,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(526, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let targetVocabulary =
-                Entities.makeVocabulary collection "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Target" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -208,13 +217,16 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(502, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Source" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -250,28 +262,36 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser2 = factory.CreateUserAsync(504, "user2@example.com", "P@ssw0rd!")
 
             let collection1 =
-                Entities.makeCollection wordfolioUser1 "Collection 1" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Collection 1" None createdAt createdAt false
 
             let sourceVocabulary =
-                Entities.makeVocabulary collection1 "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection1 "Source" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry sourceVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
 
             let collection2 =
-                Entities.makeCollection wordfolioUser2 "Collection 2" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Collection 2" None createdAt createdAt false
 
             let foreignTargetVocabulary =
-                Entities.makeVocabulary collection2 "Target" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection2 "Target" None createdAt createdAt false
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser1 "Requester Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -333,19 +353,24 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(505, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry regularVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -463,19 +488,24 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let defaultVocabulary =
-                Entities.makeVocabulary systemCollection "[Default]" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry regularVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -603,13 +633,16 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry regularVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -702,16 +735,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
             let systemCollection =
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None DateTimeOffset.UtcNow None true
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
 
             let regularCollection =
-                Entities.makeCollection wordfolioUser "Regular Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
 
             let regularVocabulary =
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry regularVocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -782,7 +819,7 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "[Default]"
                   Description = None
                   CreatedAt = createdDefaultVocabulary.CreatedAt
-                  UpdatedAt = None
+                  UpdatedAt = createdDefaultVocabulary.CreatedAt
                   IsDefault = true }
 
             Assert.Equal(expectedDefaultVocabulary, createdDefaultVocabulary)
@@ -822,13 +859,16 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(511, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -859,16 +899,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(515, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collection "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collection "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabularyA "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabularyA "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -900,16 +944,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(522, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
@@ -30,25 +30,23 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(500, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let targetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection "Target" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             let unaffectedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "stay" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "stay" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -74,11 +72,13 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! actual = response.Content.ReadFromJsonAsync<EntryResponse>()
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = targetVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -92,28 +92,24 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
                     { Id = entry.Id
                       VocabularyId = targetVocabulary.Id
                       EntryText = "hello"
-                      CreatedAt = actual.CreatedAt
+                      CreatedAt = entry.CreatedAt
                       UpdatedAt = actual.UpdatedAt }
 
             Assert.Equal(expectedMovedEntry, movedEntry)
 
             let! dbEntries = Seeder.getAllEntriesAsync fixture.WordfolioSeeder
 
-            let unaffectedEntryInDatabase =
-                dbEntries
-                |> List.find(fun currentEntry -> currentEntry.Id = unaffectedEntry.Id)
-
             let expectedDbEntries =
-                [ { unaffectedEntryInDatabase with
-                      Id = unaffectedEntry.Id
-                      VocabularyId = sourceVocabulary.Id
-                      EntryText = "stay" }
-                  { unaffectedEntryInDatabase with
-                      Id = entry.Id
-                      VocabularyId = targetVocabulary.Id
-                      EntryText = "hello"
-                      CreatedAt = actual.CreatedAt
-                      UpdatedAt = actual.UpdatedAt } ]
+                [ { Id = unaffectedEntry.Id
+                    VocabularyId = sourceVocabulary.Id
+                    EntryText = "stay"
+                    CreatedAt = unaffectedEntry.CreatedAt
+                    UpdatedAt = unaffectedEntry.UpdatedAt }
+                  { Id = entry.Id
+                    VocabularyId = targetVocabulary.Id
+                    EntryText = "hello"
+                    CreatedAt = entry.CreatedAt
+                    UpdatedAt = actual.UpdatedAt } ]
                 |> List.sortBy(fun currentEntry -> currentEntry.Id)
 
             let actualDbEntries =
@@ -133,21 +129,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(526, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let targetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection "Target" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -216,17 +211,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(502, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection "Source" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -261,37 +256,32 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(503, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(504, "user2@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection1 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Collection 1" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Collection 1" None now now false
 
             let sourceVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection1 "Source" None createdAt createdAt false
+                Entities.makeVocabulary collection1 "Source" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry sourceVocabulary "hello" createdAt createdAt
+                Entities.makeEntry sourceVocabulary "hello" now now
 
             let collection2 =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Collection 2" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Collection 2" None now now false
 
             let foreignTargetVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection2 "Target" None createdAt createdAt false
+                Entities.makeVocabulary collection2 "Target" None now now false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester entry" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -352,25 +342,23 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(505, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
+                Entities.makeEntry regularVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -398,11 +386,13 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! actual = response.Content.ReadFromJsonAsync<EntryResponse>()
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = defaultVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -487,25 +477,23 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let defaultVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary systemCollection "[Default]" None createdAt createdAt true
+                Entities.makeVocabulary systemCollection "[Default]" None now now true
 
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
+                Entities.makeEntry regularVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -530,11 +518,13 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! actual = response.Content.ReadFromJsonAsync<EntryResponse>()
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = defaultVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -632,17 +622,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
+                Entities.makeEntry regularVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -698,11 +688,13 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.Equal(expectedSystemCollection, createdSystemCollection)
             Assert.Equal(expectedDefaultVocabulary, createdDefaultVocabulary)
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expectedResponse: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = createdDefaultVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -734,21 +726,20 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let systemCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "[System] Unsorted" None createdAt createdAt true
+                Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
 
             let regularCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Regular Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Regular Collection" None now now false
 
             let regularVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary regularCollection "Regular Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary regularCollection "Regular Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry regularVocabulary "hello" createdAt createdAt
+                Entities.makeEntry regularVocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -819,16 +810,18 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "[Default]"
                   Description = None
                   CreatedAt = createdDefaultVocabulary.CreatedAt
-                  UpdatedAt = createdDefaultVocabulary.CreatedAt
+                  UpdatedAt = createdDefaultVocabulary.UpdatedAt
                   IsDefault = true }
 
             Assert.Equal(expectedDefaultVocabulary, createdDefaultVocabulary)
+
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expectedResponse: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = createdDefaultVocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = []
                   Translations = [] }
@@ -858,17 +851,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(511, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -898,21 +891,19 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(515, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary B" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabularyA "hello" createdAt createdAt
+                Entities.makeEntry vocabularyA "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -943,21 +934,19 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(522, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
@@ -28,13 +28,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(311, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let oldDefinition =
                 Entities.makeDefinition
@@ -51,7 +54,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                     0
 
             let unaffectedEntry =
-                Entities.makeEntry vocabulary "stay unchanged" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "stay unchanged" createdAt createdAt
 
             let unaffectedDefinition =
                 Entities.makeDefinition
@@ -255,13 +259,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(323, "auth@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Auth Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Auth Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Auth Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Auth Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "protected entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "protected entry" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -350,13 +357,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(312, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -445,13 +455,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(313, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let definition =
                 Entities.makeDefinition
@@ -554,13 +567,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(316, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -648,13 +664,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(318, "user2@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser1 "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             let ownerDefinition =
                 Entities.makeDefinition
@@ -671,13 +690,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                     0
 
             let requesterCollection =
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             let requesterEntry =
-                Entities.makeEntry requesterVocabulary "requester entry" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
 
             let requesterDefinition =
                 Entities.makeDefinition
@@ -824,13 +846,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(509, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -866,16 +891,20 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(513, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabularyA =
-                Entities.makeVocabulary collection "Vocabulary A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
 
             let vocabularyB =
-                Entities.makeVocabulary collection "Vocabulary B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabularyA "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabularyA "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder
@@ -912,16 +941,20 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(520, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             let entry =
-                Entities.makeEntry vocabulary "hello" DateTimeOffset.UtcNow None
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeEntry vocabulary "hello" createdAt createdAt
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
@@ -27,17 +27,17 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(311, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let oldDefinition =
                 Entities.makeDefinition
@@ -54,8 +54,7 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                     0
 
             let unaffectedEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "stay unchanged" createdAt createdAt
+                Entities.makeEntry vocabulary "stay unchanged" now now
 
             let unaffectedDefinition =
                 Entities.makeDefinition
@@ -133,11 +132,13 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   DisplayOrder = 0
                   Examples = [ expectedTranslationExample ] }
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello updated"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [ expectedTranslation ] }
@@ -258,17 +259,17 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(323, "auth@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Auth Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Auth Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Auth Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Auth Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "protected entry" createdAt createdAt
+                Entities.makeEntry vocabulary "protected entry" now now
 
             let definition =
                 Entities.makeDefinition
@@ -356,17 +357,17 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(312, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition
@@ -454,17 +455,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(313, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let definition =
                 Entities.makeDefinition
@@ -566,17 +566,17 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(316, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -614,11 +614,13 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   DisplayOrder = 0
                   Examples = [] }
 
+            Assert.True(actual.UpdatedAt >= entry.CreatedAt)
+
             let expected: EntryResponse =
                 { Id = entry.Id
                   VocabularyId = vocabulary.Id
                   EntryText = "hello"
-                  CreatedAt = actual.CreatedAt
+                  CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
                   Definitions = [ expectedDefinition ]
                   Translations = [] }
@@ -663,17 +665,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(317, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(318, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             let ownerDefinition =
                 Entities.makeDefinition
@@ -690,16 +691,13 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                     0
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             let requesterEntry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry requesterVocabulary "requester entry" createdAt createdAt
+                Entities.makeEntry requesterVocabulary "requester entry" now now
 
             let requesterDefinition =
                 Entities.makeDefinition
@@ -845,17 +843,16 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(509, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -890,21 +887,19 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(513, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabularyA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary A" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary A" None now now false
 
             let vocabularyB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Vocabulary B" None createdAt createdAt false
+                Entities.makeVocabulary collection "Vocabulary B" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabularyA "hello" createdAt createdAt
+                Entities.makeEntry vocabularyA "hello" now now
 
             do!
                 fixture.WordfolioSeeder
@@ -940,21 +935,19 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(520, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None now now false
 
             let entry =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeEntry vocabulary "hello" createdAt createdAt
+                Entities.makeEntry vocabulary "hello" now now
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
@@ -27,9 +27,11 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(200, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -56,27 +58,25 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdVocabularyId = result.Id
 
-            let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
-
-            let createdAt = databaseState.Head.CreatedAt
-
             let expectedResult: VocabularyResponse =
                 { Id = createdVocabularyId
                   CollectionId = collection.Id
                   Name = "Test Vocabulary"
                   Description = Some "A test vocabulary"
-                  CreatedAt = createdAt
-                  UpdatedAt = createdAt }
+                  CreatedAt = result.CreatedAt
+                  UpdatedAt = result.CreatedAt }
 
             Assert.Equal(expectedResult, result)
+
+            let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
 
             let expectedDatabaseState: Wordfolio.Vocabulary list =
                 [ { Id = createdVocabularyId
                     CollectionId = collection.Id
                     Name = "Test Vocabulary"
                     Description = Some "A test vocabulary"
-                    CreatedAt = createdAt
-                    UpdatedAt = createdAt
+                    CreatedAt = result.CreatedAt
+                    UpdatedAt = result.CreatedAt
                     IsDefault = false } ]
 
             Assert.Equal<Vocabulary list>(expectedDatabaseState, databaseState)
@@ -92,9 +92,11 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -133,9 +135,11 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(207, "requester@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -171,9 +175,11 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(201, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
@@ -28,7 +28,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(200, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -61,7 +62,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Test Vocabulary"
                   Description = Some "A test vocabulary"
                   CreatedAt = result.CreatedAt
-                  UpdatedAt = None }
+                  UpdatedAt = result.CreatedAt }
 
             Assert.Equal(expectedResult, result)
 
@@ -71,7 +72,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                     Name = "Test Vocabulary"
                     Description = Some "A test vocabulary"
                     CreatedAt = result.CreatedAt
-                    UpdatedAt = None
+                    UpdatedAt = result.CreatedAt
                     IsDefault = false } ]
 
             let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
@@ -90,7 +91,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -130,7 +132,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(207, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -167,7 +170,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(201, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
@@ -56,13 +56,17 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdVocabularyId = result.Id
 
+            let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
+
+            let createdAt = databaseState.Head.CreatedAt
+
             let expectedResult: VocabularyResponse =
                 { Id = createdVocabularyId
                   CollectionId = collection.Id
                   Name = "Test Vocabulary"
                   Description = Some "A test vocabulary"
-                  CreatedAt = result.CreatedAt
-                  UpdatedAt = result.CreatedAt }
+                  CreatedAt = createdAt
+                  UpdatedAt = createdAt }
 
             Assert.Equal(expectedResult, result)
 
@@ -71,11 +75,9 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                     CollectionId = collection.Id
                     Name = "Test Vocabulary"
                     Description = Some "A test vocabulary"
-                    CreatedAt = result.CreatedAt
-                    UpdatedAt = result.CreatedAt
+                    CreatedAt = createdAt
+                    UpdatedAt = createdAt
                     IsDefault = false } ]
-
-            let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
 
             Assert.Equal<Vocabulary list>(expectedDatabaseState, databaseState)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
@@ -26,10 +26,12 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -67,7 +69,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(209, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -96,16 +99,18 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(218, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 10, 0, 0, TimeSpan.Zero)
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt None false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -134,7 +139,7 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Test Vocabulary"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabaseOption)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
@@ -25,13 +25,13 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -68,9 +68,10 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(209, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -98,13 +99,13 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(218, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 10, 0, 0, TimeSpan.Zero)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
@@ -28,13 +28,16 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "My Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "My Collection" None createdAt createdAt false
 
             let firstVocabulary =
-                Entities.makeVocabulary collection "Animals" (Some "Animal words") DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Animals" (Some "Animal words") createdAt createdAt false
 
             let secondVocabulary =
-                Entities.makeVocabulary collection "Travel" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Travel" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -66,13 +69,13 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
                      Name = "Animals"
                      Description = Some "Animal words"
                      CreatedAt = sortedResult[0].CreatedAt
-                     UpdatedAt = None }
+                     UpdatedAt = sortedResult[0].CreatedAt }
                    { Id = secondVocabulary.Id
                      CollectionId = collection.Id
                      Name = "Travel"
                      Description = None
                      CreatedAt = sortedResult[1].CreatedAt
-                     UpdatedAt = None } |]
+                     UpdatedAt = sortedResult[1].CreatedAt } |]
                 |> Array.sortBy _.Id
 
             Assert.Equal<VocabularyResponse>(expected, sortedResult)
@@ -89,7 +92,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -145,22 +149,20 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(210, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
 
             let ownerVocabulary =
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
 
             let requesterCollection =
-                Entities.makeCollection
-                    requesterWordfolioUser
-                    "Requester Collection"
-                    None
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
@@ -27,17 +27,16 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "My Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "My Collection" None now now false
 
             let firstVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Animals" (Some "Animal words") createdAt createdAt false
+                Entities.makeVocabulary collection "Animals" (Some "Animal words") now now false
 
             let secondVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Travel" None createdAt createdAt false
+                Entities.makeVocabulary collection "Travel" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -91,9 +90,10 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -148,21 +148,19 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(210, "requester@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
 
             let ownerVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" None now now false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary requesterCollection "Requester Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
@@ -27,13 +27,14 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(203, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "Test Vocabulary" (Some "Test Description") createdAt createdAt false
+                Entities.makeVocabulary collection "Test Vocabulary" (Some "Test Description") timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -61,7 +62,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Test Vocabulary"
                   Description = Some "Test Description"
                   CreatedAt = vocabulary.CreatedAt
-                  UpdatedAt = vocabulary.CreatedAt }
+                  UpdatedAt = vocabulary.UpdatedAt }
 
             Assert.Equal(expected, actual)
         }
@@ -76,9 +77,11 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(204, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -106,17 +109,17 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(216, "user@example.com", "P@ssw0rd!")
 
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None timestamp timestamp false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None timestamp timestamp false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "Test Vocabulary" None timestamp timestamp false
 
             do!
                 fixture.WordfolioSeeder
@@ -148,26 +151,25 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(212, "requester@example.com", "P@ssw0rd!")
 
-            let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
+            let timestamp =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
+            let ownerCollection =
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             let ownerVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeVocabulary
                     ownerCollection
                     "Owner Vocabulary"
                     (Some "Owner Vocabulary Description")
-                    createdAt
-                    createdAt
+                    timestamp
+                    timestamp
                     false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
@@ -60,8 +60,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
                   CollectionName = "Test Collection"
                   Name = "Test Vocabulary"
                   Description = Some "Test Description"
-                  CreatedAt = actual.CreatedAt
-                  UpdatedAt = actual.CreatedAt }
+                  CreatedAt = vocabulary.CreatedAt
+                  UpdatedAt = vocabulary.CreatedAt }
 
             Assert.Equal(expected, actual)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
@@ -28,16 +28,12 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(203, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary
-                    collection
-                    "Test Vocabulary"
-                    (Some "Test Description")
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "Test Vocabulary" (Some "Test Description") createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -65,7 +61,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Name = "Test Vocabulary"
                   Description = Some "Test Description"
                   CreatedAt = actual.CreatedAt
-                  UpdatedAt = None }
+                  UpdatedAt = actual.CreatedAt }
 
             Assert.Equal(expected, actual)
         }
@@ -81,7 +77,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(204, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -110,13 +107,16 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(216, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Test Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "Test Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -149,21 +149,25 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(212, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeCollection
                     ownerWordfolioUser
                     "Owner Collection"
                     (Some "Owner Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let ownerVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     ownerCollection
                     "Owner Vocabulary"
                     (Some "Owner Vocabulary Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
@@ -31,16 +31,18 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                 DateTimeOffset(2026, 1, 10, 10, 0, 0, TimeSpan.Zero)
 
             let sourceCollection =
-                Entities.makeCollection wordfolioUser "Source Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Source Collection" None createdAt createdAt false
 
             let targetCollection =
-                Entities.makeCollection wordfolioUser "Target Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Target Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt None false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             let unaffectedVocabulary =
-                Entities.makeVocabulary sourceCollection "Stay Here" None createdAt None false
+                Entities.makeVocabulary sourceCollection "Stay Here" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -74,7 +76,7 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   UpdatedAt = actual.UpdatedAt }
 
             Assert.Equal(expected, actual)
-            Assert.True(actual.UpdatedAt.IsSome)
+            Assert.True(actual.UpdatedAt >= createdAt)
 
             let! movedVocabulary =
                 fixture.WordfolioSeeder
@@ -138,7 +140,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(601, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -167,10 +170,12 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(602, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collection "My Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collection "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -201,13 +206,16 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(603, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "My Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary collectionB "My Vocabulary" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -237,7 +245,7 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = vocabularyInDatabase.Value.CreatedAt
-                      UpdatedAt = None
+                      UpdatedAt = vocabularyInDatabase.Value.CreatedAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabase)
@@ -255,13 +263,16 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser2 = factory.CreateUserAsync(605, "user2@example.com", "P@ssw0rd!")
 
             let sourceCollection =
-                Entities.makeCollection wordfolioUser1 "Source" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser1 "Source" None createdAt createdAt false
 
             let vocabulary =
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
 
             let foreignCollection =
-                Entities.makeCollection wordfolioUser2 "Foreign" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser2 "Foreign" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -294,7 +305,7 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "My Vocabulary"
                       Description = None
                       CreatedAt = vocabularyInDatabase.Value.CreatedAt
-                      UpdatedAt = None
+                      UpdatedAt = vocabularyInDatabase.Value.CreatedAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabase)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
@@ -27,16 +27,16 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(600, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 10, 0, 0, TimeSpan.Zero)
 
             let sourceCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Source Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Source Collection" None now now false
 
             let targetCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Target Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Target Collection" None now now false
 
             let vocabulary =
                 Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
@@ -139,9 +139,10 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(601, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -169,13 +170,13 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(602, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collection "My Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collection "My Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -205,17 +206,16 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(603, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary collectionB "My Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary collectionB "My Vocabulary" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -262,17 +262,16 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(604, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(605, "user2@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let sourceCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser1 "Source" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser1 "Source" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeVocabulary sourceCollection "My Vocabulary" None createdAt createdAt false
+                Entities.makeVocabulary sourceCollection "My Vocabulary" None now now false
 
             let foreignCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser2 "Foreign" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser2 "Foreign" None now now false
 
             do!
                 fixture.WordfolioSeeder

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
@@ -28,24 +28,29 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(205, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let vocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     collection
                     "Original Name"
                     (Some "Original Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let unaffectedVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     collection
                     "Unaffected Vocabulary"
                     (Some "Unaffected Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -131,7 +136,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(206, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -168,16 +174,24 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(217, "user@example.com", "P@ssw0rd!")
 
             let collectionA =
-                Entities.makeCollection wordfolioUser "Collection A" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
 
             let collectionB =
-                Entities.makeCollection wordfolioUser "Collection B" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 8, 30, 0, TimeSpan.Zero)
 
             let vocabulary =
-                Entities.makeVocabulary collectionB "Original Name" (Some "Original Description") createdAt None false
+                Entities.makeVocabulary
+                    collectionB
+                    "Original Name"
+                    (Some "Original Description")
+                    createdAt
+                    createdAt
+                    false
 
             do!
                 fixture.WordfolioSeeder
@@ -210,7 +224,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Original Name"
                       Description = Some "Original Description"
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabaseOption)
@@ -230,33 +244,33 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(214, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
 
             let ownerVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     ownerCollection
                     "Owner Vocabulary"
                     (Some "Owner Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             let requesterCollection =
-                Entities.makeCollection
-                    requesterWordfolioUser
-                    "Requester Collection"
-                    None
-                    DateTimeOffset.UtcNow
-                    None
-                    false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
 
             let requesterVocabulary =
+                let createdAt = DateTimeOffset.UtcNow
+
                 Entities.makeVocabulary
                     requesterCollection
                     "Requester Vocabulary"
                     (Some "Requester Description")
-                    DateTimeOffset.UtcNow
-                    None
+                    createdAt
+                    createdAt
                     false
 
             do!
@@ -329,13 +343,14 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(207, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 9, 0, 0, TimeSpan.Zero)
 
             let vocabulary =
-                Entities.makeVocabulary collection "Original Name" None createdAt None false
+                Entities.makeVocabulary collection "Original Name" None createdAt createdAt false
 
             do!
                 fixture.WordfolioSeeder
@@ -368,7 +383,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Original Name"
                       Description = None
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabaseOption)
@@ -385,13 +400,20 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser = factory.CreateUserAsync(215, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                Entities.makeCollection wordfolioUser "Test Collection" None DateTimeOffset.UtcNow None false
+                let createdAt = DateTimeOffset.UtcNow
+                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 9, 30, 0, TimeSpan.Zero)
 
             let vocabulary =
-                Entities.makeVocabulary collection "Original Name" (Some "Original Description") createdAt None false
+                Entities.makeVocabulary
+                    collection
+                    "Original Name"
+                    (Some "Original Description")
+                    createdAt
+                    createdAt
+                    false
 
             do!
                 fixture.WordfolioSeeder
@@ -424,7 +446,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                       Name = "Original Name"
                       Description = Some "Original Description"
                       CreatedAt = createdAt
-                      UpdatedAt = None
+                      UpdatedAt = createdAt
                       IsDefault = false }
 
             Assert.Equal(expectedVocabularyInDatabase, vocabularyInDatabaseOption)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
@@ -27,31 +27,17 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(205, "user@example.com", "P@ssw0rd!")
 
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-
-                Entities.makeVocabulary
-                    collection
-                    "Original Name"
-                    (Some "Original Description")
-                    createdAt
-                    createdAt
-                    false
+                Entities.makeVocabulary collection "Original Name" (Some "Original Description") now now false
 
             let unaffectedVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-
-                Entities.makeVocabulary
-                    collection
-                    "Unaffected Vocabulary"
-                    (Some "Unaffected Description")
-                    createdAt
-                    createdAt
-                    false
+                Entities.makeVocabulary collection "Unaffected Vocabulary" (Some "Unaffected Description") now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -81,10 +67,15 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   CollectionId = collection.Id
                   Name = "Updated Name"
                   Description = Some "Updated Description"
-                  CreatedAt = actualResponse.CreatedAt
+                  CreatedAt = vocabulary.CreatedAt
                   UpdatedAt = actualResponse.UpdatedAt }
 
             Assert.Equal(expectedResponse, actualResponse)
+
+            Assert.True(
+                actualResponse.UpdatedAt
+                >= vocabulary.CreatedAt
+            )
 
             let! vocabularies = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
 
@@ -135,9 +126,10 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(206, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             do!
                 fixture.WordfolioSeeder
@@ -173,13 +165,13 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(217, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collectionA =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection A" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection A" None now now false
 
             let collectionB =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Collection B" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Collection B" None now now false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 8, 30, 0, TimeSpan.Zero)
@@ -243,34 +235,24 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(214, "requester@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection ownerWordfolioUser "Owner Collection" None createdAt createdAt false
+                Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
 
             let ownerVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-
-                Entities.makeVocabulary
-                    ownerCollection
-                    "Owner Vocabulary"
-                    (Some "Owner Description")
-                    createdAt
-                    createdAt
-                    false
+                Entities.makeVocabulary ownerCollection "Owner Vocabulary" (Some "Owner Description") now now false
 
             let requesterCollection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection requesterWordfolioUser "Requester Collection" None createdAt createdAt false
+                Entities.makeCollection requesterWordfolioUser "Requester Collection" None now now false
 
             let requesterVocabulary =
-                let createdAt = DateTimeOffset.UtcNow
-
                 Entities.makeVocabulary
                     requesterCollection
                     "Requester Vocabulary"
                     (Some "Requester Description")
-                    createdAt
-                    createdAt
+                    now
+                    now
                     false
 
             do!
@@ -342,9 +324,10 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(207, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 9, 0, 0, TimeSpan.Zero)
@@ -399,9 +382,10 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(215, "user@example.com", "P@ssw0rd!")
 
+            let now = DateTimeOffset.UtcNow
+
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
-                Entities.makeCollection wordfolioUser "Test Collection" None createdAt createdAt false
+                Entities.makeCollection wordfolioUser "Test Collection" None now now false
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 9, 30, 0, TimeSpan.Zero)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Collections/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Collections/Types.fs
@@ -7,7 +7,7 @@ type CollectionResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type CreateCollectionRequest =
     { Name: string

--- a/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Types.fs
@@ -7,7 +7,7 @@ type VocabularyWithEntryCountResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       EntryCount: int }
 
 type CollectionWithVocabulariesResponse =
@@ -15,7 +15,7 @@ type CollectionWithVocabulariesResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       Vocabularies: VocabularyWithEntryCountResponse list }
 
 type CollectionWithVocabularyCountResponse =
@@ -23,7 +23,7 @@ type CollectionWithVocabularyCountResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       VocabularyCount: int }
 
 type CollectionsHierarchyResultResponse =

--- a/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Types.fs
@@ -17,7 +17,7 @@ type VocabularyResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type DraftsVocabularyDataResponse =
     { Vocabulary: VocabularyResponse

--- a/Wordfolio.Api/Wordfolio.Api/Api/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Types.fs
@@ -64,6 +64,6 @@ type EntryResponse =
       VocabularyId: int
       EntryText: string
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option
+      UpdatedAt: DateTimeOffset
       Definitions: DefinitionResponse list
       Translations: TranslationResponse list }

--- a/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Types.fs
@@ -8,7 +8,7 @@ type VocabularyResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type VocabularyDetailResponse =
     { Id: int
@@ -17,7 +17,7 @@ type VocabularyDetailResponse =
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
-      UpdatedAt: DateTimeOffset option }
+      UpdatedAt: DateTimeOffset }
 
 type CreateVocabularyRequest =
     { Name: string

--- a/Wordfolio.Frontend/src/features/entries/pages/EntryDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/entries/pages/EntryDetailPage.tsx
@@ -192,7 +192,7 @@ export const EntryDetailPage = () => {
                 title={isLoading ? "Loading..." : (entry?.entryText ?? "Entry")}
                 description={
                     entry
-                        ? `Added ${entry.createdAt.toLocaleDateString()}${entry.updatedAt ? ` · Updated ${entry.updatedAt.toLocaleDateString()}` : ""}`
+                        ? `Added ${entry.createdAt.toLocaleDateString()} · Updated ${entry.updatedAt.toLocaleDateString()}`
                         : undefined
                 }
                 actions={

--- a/Wordfolio.Frontend/src/shared/api/generated/schema.d.ts
+++ b/Wordfolio.Frontend/src/shared/api/generated/schema.d.ts
@@ -1817,7 +1817,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
         };
         CollectionsHierarchyResultResponse: {
             collections: components["schemas"]["CollectionWithVocabulariesResponse"][];
@@ -1831,7 +1831,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
             vocabularies: components["schemas"]["VocabularyWithEntryCountResponse"][];
         };
         CollectionWithVocabularyCountResponse: {
@@ -1842,7 +1842,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
             /** Format: int32 */
             vocabularyCount: number;
         };
@@ -1895,7 +1895,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
             definitions: components["schemas"]["DefinitionResponse"][];
             translations: components["schemas"]["TranslationResponse"][];
         };
@@ -2031,7 +2031,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
         };
         VocabularyResponse: {
             /** Format: int32 */
@@ -2043,7 +2043,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
         };
         VocabularyWithEntryCountResponse: {
             /** Format: int32 */
@@ -2053,7 +2053,7 @@ export interface components {
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
-            updatedAt?: null | string;
+            updatedAt: string;
             /** Format: int32 */
             entryCount: number;
         };

--- a/Wordfolio.Frontend/src/shared/api/mappers/collections.ts
+++ b/Wordfolio.Frontend/src/shared/api/mappers/collections.ts
@@ -24,7 +24,7 @@ export const mapCollectionDetail = (
     name: response.name,
     description: response.description ?? null,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });
 
 export const mapCollectionWithVocabularyCount = (
@@ -35,7 +35,7 @@ export const mapCollectionWithVocabularyCount = (
     description: response.description ?? null,
     vocabularyCount: response.vocabularyCount,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });
 
 export const mapVocabularyWithEntryCount = (
@@ -46,7 +46,7 @@ export const mapVocabularyWithEntryCount = (
     description: response.description ?? null,
     entryCount: response.entryCount,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });
 
 const mapCollectionWithVocabularies = (
@@ -56,7 +56,7 @@ const mapCollectionWithVocabularies = (
     name: response.name,
     description: response.description ?? null,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
     vocabularies: response.vocabularies.map((v) =>
         mapVocabularyWithEntryCount(v)
     ),

--- a/Wordfolio.Frontend/src/shared/api/mappers/drafts.ts
+++ b/Wordfolio.Frontend/src/shared/api/mappers/drafts.ts
@@ -10,5 +10,5 @@ export const mapDraftsVocabulary = (
     name: response.name,
     description: response.description ?? null,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });

--- a/Wordfolio.Frontend/src/shared/api/mappers/entries.ts
+++ b/Wordfolio.Frontend/src/shared/api/mappers/entries.ts
@@ -128,7 +128,7 @@ export const mapEntry = (response: EntryResponse): Entry => ({
     vocabularyId: response.vocabularyId,
     entryText: response.entryText,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
     definitions: response.definitions.map(mapDefinition),
     translations: response.translations.map(mapTranslation),
 });

--- a/Wordfolio.Frontend/src/shared/api/mappers/vocabularies.ts
+++ b/Wordfolio.Frontend/src/shared/api/mappers/vocabularies.ts
@@ -16,7 +16,7 @@ export const mapVocabulary = (response: VocabularyResponse): Vocabulary => ({
     name: response.name,
     description: response.description ?? null,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });
 
 export const mapVocabularyDetail = (
@@ -28,7 +28,7 @@ export const mapVocabularyDetail = (
     name: response.name,
     description: response.description ?? null,
     createdAt: new Date(response.createdAt),
-    updatedAt: response.updatedAt ? new Date(response.updatedAt) : null,
+    updatedAt: new Date(response.updatedAt),
 });
 
 export const mapVocabularyCollectionContext = (

--- a/Wordfolio.Frontend/src/shared/api/types/collections.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/collections.ts
@@ -3,7 +3,7 @@ export interface Collection {
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface CollectionWithVocabularyCount {
@@ -12,7 +12,7 @@ export interface CollectionWithVocabularyCount {
     readonly description: string | null;
     readonly vocabularyCount: number;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface VocabularyWithEntryCount {
@@ -21,7 +21,7 @@ export interface VocabularyWithEntryCount {
     readonly description: string | null;
     readonly entryCount: number;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface CollectionWithVocabularies {
@@ -29,7 +29,7 @@ export interface CollectionWithVocabularies {
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
     readonly vocabularies: VocabularyWithEntryCount[];
 }
 

--- a/Wordfolio.Frontend/src/shared/api/types/drafts.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/drafts.ts
@@ -5,7 +5,7 @@ export interface DraftsVocabulary {
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface DraftsData {

--- a/Wordfolio.Frontend/src/shared/api/types/entries.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/entries.ts
@@ -42,7 +42,7 @@ export interface Entry {
     readonly vocabularyId: number;
     readonly entryText: string;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
     readonly definitions: Definition[];
     readonly translations: Translation[];
 }

--- a/Wordfolio.Frontend/src/shared/api/types/vocabularies.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/vocabularies.ts
@@ -4,7 +4,7 @@ export interface Vocabulary {
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface VocabularyDetail {
@@ -14,7 +14,7 @@ export interface VocabularyDetail {
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export interface VocabularyCollectionContext {

--- a/Wordfolio.Frontend/src/shared/components/entries/EntryFooter.tsx
+++ b/Wordfolio.Frontend/src/shared/components/entries/EntryFooter.tsx
@@ -4,7 +4,7 @@ import styles from "./EntryFooter.module.scss";
 
 interface EntryFooterProps {
     readonly createdAt: Date;
-    readonly updatedAt: Date | null;
+    readonly updatedAt: Date;
 }
 
 export const EntryFooter = ({ createdAt, updatedAt }: EntryFooterProps) => (
@@ -12,8 +12,8 @@ export const EntryFooter = ({ createdAt, updatedAt }: EntryFooterProps) => (
         <Divider className={styles.divider} />
         <Box className={styles.footer}>
             <Typography variant="body2" color="text.secondary">
-                Added {createdAt.toLocaleDateString()}
-                {updatedAt && ` · Updated ${updatedAt.toLocaleDateString()}`}
+                Added {createdAt.toLocaleDateString()} · Updated{" "}
+                {updatedAt.toLocaleDateString()}
             </Typography>
         </Box>
     </>

--- a/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
@@ -20,7 +20,7 @@ const createHierarchy = (
             name: "English Collection",
             description: null,
             createdAt: new Date(),
-            updatedAt: null,
+            updatedAt: new Date(),
             vocabularies: [
                 {
                     id: 10,
@@ -28,7 +28,7 @@ const createHierarchy = (
                     description: null,
                     entryCount: 5,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             ],
         },
@@ -39,7 +39,7 @@ const createHierarchy = (
         description: null,
         entryCount: 3,
         createdAt: new Date(),
-        updatedAt: null,
+        updatedAt: new Date(),
     },
     ...overrides,
 });
@@ -84,7 +84,7 @@ describe("MoveEntryDialog", () => {
                     description: null,
                     entryCount: 3,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             }),
             isLoading: false,

--- a/Wordfolio.Frontend/tests/shared/components/VocabularySelector.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/VocabularySelector.test.tsx
@@ -16,7 +16,7 @@ const createHierarchy = (
             name: "English Collection",
             description: null,
             createdAt: new Date(),
-            updatedAt: null,
+            updatedAt: new Date(),
             vocabularies: [
                 {
                     id: 10,
@@ -24,7 +24,7 @@ const createHierarchy = (
                     description: null,
                     entryCount: 5,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
                 {
                     id: 11,
@@ -32,7 +32,7 @@ const createHierarchy = (
                     description: null,
                     entryCount: 3,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             ],
         },
@@ -41,7 +41,7 @@ const createHierarchy = (
             name: "Spanish Collection",
             description: null,
             createdAt: new Date(),
-            updatedAt: null,
+            updatedAt: new Date(),
             vocabularies: [
                 {
                     id: 20,
@@ -49,7 +49,7 @@ const createHierarchy = (
                     description: null,
                     entryCount: 10,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             ],
         },
@@ -128,7 +128,7 @@ describe("VocabularySelector", () => {
                     description: null,
                     entryCount: 0,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             }),
         });
@@ -178,7 +178,7 @@ describe("VocabularySelector", () => {
                     description: null,
                     entryCount: 0,
                     createdAt: new Date(),
-                    updatedAt: null,
+                    updatedAt: new Date(),
                 },
             }),
             excludeVocabularyId: 99,

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1675,7 +1675,8 @@
         "required": [
           "id",
           "name",
-          "createdAt"
+          "createdAt",
+          "updatedAt"
         ],
         "type": "object",
         "properties": {
@@ -1697,10 +1698,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           }
         }
@@ -1734,6 +1732,7 @@
           "id",
           "name",
           "createdAt",
+          "updatedAt",
           "vocabularies"
         ],
         "type": "object",
@@ -1756,10 +1755,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           },
           "vocabularies": {
@@ -1775,6 +1771,7 @@
           "id",
           "name",
           "createdAt",
+          "updatedAt",
           "vocabularyCount"
         ],
         "type": "object",
@@ -1797,10 +1794,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           },
           "vocabularyCount": {
@@ -1989,6 +1983,7 @@
           "vocabularyId",
           "entryText",
           "createdAt",
+          "updatedAt",
           "definitions",
           "translations"
         ],
@@ -2010,10 +2005,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           },
           "definitions": {
@@ -2500,7 +2492,8 @@
           "collectionId",
           "collectionName",
           "name",
-          "createdAt"
+          "createdAt",
+          "updatedAt"
         ],
         "type": "object",
         "properties": {
@@ -2529,10 +2522,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           }
         }
@@ -2542,7 +2532,8 @@
           "id",
           "collectionId",
           "name",
-          "createdAt"
+          "createdAt",
+          "updatedAt"
         ],
         "type": "object",
         "properties": {
@@ -2568,10 +2559,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           }
         }
@@ -2581,6 +2569,7 @@
           "id",
           "name",
           "createdAt",
+          "updatedAt",
           "entryCount"
         ],
         "type": "object",
@@ -2603,10 +2592,7 @@
             "format": "date-time"
           },
           "updatedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": "string",
             "format": "date-time"
           },
           "entryCount": {


### PR DESCRIPTION
## Summary
- make `updatedAt` non-nullable across backend, API contracts, generated types, and frontend models
- set `updatedAt = createdAt` on create flows and add a schema migration enforcing NOT NULL
- update backend/frontend tests and UI rendering for always-present updated timestamps

Closes #232