### PR TITLE
Use specific dates in tests

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/CreateTests.fs
@@ -50,7 +50,8 @@ let makeCollection id userId name description createdAt =
 [<Fact>]
 let ``creates collection with valid name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let createdCollection =
             makeCollection 1 1 "Test Collection" None now
@@ -105,7 +106,9 @@ let ``creates collection with valid name``() =
 [<Fact>]
 let ``creates collection with description``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let description = Some "A test description"
 
         let createdCollection =
@@ -147,7 +150,8 @@ let ``creates collection with description``() =
 [<Fact>]
 let ``trims whitespace from name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let createdCollection =
             makeCollection 1 1 "Test Collection" None now
@@ -200,7 +204,7 @@ let ``returns error when name is empty``() =
                 { UserId = UserId 1
                   Name = ""
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error CreateCollectionError.CollectionNameRequired, result)
         Assert.Empty(env.CreateCollectionCalls)
@@ -222,7 +226,7 @@ let ``returns error when name is whitespace only``() =
                 { UserId = UserId 1
                   Name = "   "
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error CreateCollectionError.CollectionNameRequired, result)
         Assert.Empty(env.CreateCollectionCalls)
@@ -246,7 +250,7 @@ let ``returns error when name exceeds max length``() =
                 { UserId = UserId 1
                   Name = longName
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(CreateCollectionError.CollectionNameTooLong MaxNameLength), result)
         Assert.Empty(env.CreateCollectionCalls)
@@ -256,7 +260,8 @@ let ``returns error when name exceeds max length``() =
 [<Fact>]
 let ``accepts name at exact max length``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let maxLengthName =
             String.replicate MaxNameLength "a"
@@ -300,7 +305,8 @@ let ``accepts name at exact max length``() =
 [<Fact>]
 let ``throws when post-creation collection fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let env =
             TestEnv(

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/DeleteTests.fs
@@ -36,7 +36,8 @@ type TestEnv(getCollectionById: CollectionId -> Task<Collection option>, deleteC
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByIdTests.fs
@@ -25,7 +25,8 @@ type TestEnv(getCollectionById: CollectionId -> Task<Collection option>) =
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByUserIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/GetByUserIdTests.fs
@@ -26,7 +26,8 @@ type TestEnv(getCollectionsByUserId: UserId -> Task<Collection list>) =
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Collections/UpdateTests.fs
@@ -38,7 +38,7 @@ type TestEnv
 
 let makeCollection id userId name description =
     let createdAt =
-        DateTimeOffset.UtcNow.AddDays(-1)
+        (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)).AddDays(-1)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -50,7 +50,8 @@ let makeCollection id userId name description =
 [<Fact>]
 let ``updates collection when owned by user``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingCollection =
             makeCollection 1 1 "Old Name" None
@@ -120,7 +121,8 @@ let ``updates collection when owned by user``() =
 [<Fact>]
 let ``trims whitespace from name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingCollection =
             makeCollection 1 1 "Old Name" None
@@ -161,7 +163,8 @@ let ``trims whitespace from name``() =
 [<Fact>]
 let ``clears description when updated to None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingCollection =
             makeCollection 1 1 "Test Collection" (Some "old description")
@@ -218,7 +221,7 @@ let ``returns NotFound when collection does not exist``() =
                   CollectionId = CollectionId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateCollectionError.CollectionNotFound(CollectionId 1)), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -249,7 +252,7 @@ let ``returns AccessDenied when collection owned by different user``() =
                   CollectionId = CollectionId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateCollectionError.CollectionAccessDenied(CollectionId 1)), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -275,7 +278,7 @@ let ``returns error when name is empty``() =
                   CollectionId = CollectionId 1
                   Name = ""
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateCollectionError.CollectionNameRequired, result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -303,7 +306,7 @@ let ``returns error when name exceeds max length``() =
                   CollectionId = CollectionId 1
                   Name = longName
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateCollectionError.CollectionNameTooLong MaxNameLength), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -329,7 +332,7 @@ let ``returns error when name is whitespace only``() =
                   CollectionId = CollectionId 1
                   Name = "   "
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateCollectionError.CollectionNameRequired, result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -339,7 +342,8 @@ let ``returns error when name is whitespace only``() =
 [<Fact>]
 let ``accepts name at exact max length``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingCollection =
             makeCollection 1 1 "Old Name" None
@@ -383,7 +387,8 @@ let ``accepts name at exact max length``() =
 [<Fact>]
 let ``returns NotFound when update affects no rows``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingCollection =
             makeCollection 1 1 "Test Collection" None

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/CreateTests.fs
@@ -120,7 +120,8 @@ type TestEnv
         member _.CreateDefaultCollection(parameters) = createDefaultCollection parameters
 
 let makeVocabulary id collectionId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
@@ -183,7 +184,8 @@ let defaultVocabulary =
 [<Fact>]
 let ``creates entry with definitions only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]
@@ -225,7 +227,8 @@ let ``creates entry with definitions only``() =
 [<Fact>]
 let ``creates entry with translations only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let translationInputs =
             [ makeTranslationInput "test translation" TranslationSource.Manual [] ]
@@ -267,7 +270,8 @@ let ``creates entry with translations only``() =
 [<Fact>]
 let ``creates entry with both definitions and translations``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]
@@ -316,7 +320,8 @@ let ``creates entry with both definitions and translations``() =
 [<Fact>]
 let ``trims whitespace from entry text``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]
@@ -380,7 +385,7 @@ let ``returns error when entry text is empty``() =
                     ""
                     [ makeDefinitionInput "test" DefinitionSource.Manual [] ]
                     []
-                    DateTimeOffset.UtcNow)
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error CreateDraftEntryError.EntryTextRequired, result)
         Assert.Empty(env.CreateEntryCalls)
@@ -412,7 +417,7 @@ let ``returns error when entry text is whitespace only``() =
                     "   "
                     [ makeDefinitionInput "test" DefinitionSource.Manual [] ]
                     []
-                    DateTimeOffset.UtcNow)
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error CreateDraftEntryError.EntryTextRequired, result)
     }
@@ -445,7 +450,7 @@ let ``returns error when entry text exceeds max length``() =
                     longText
                     [ makeDefinitionInput "test" DefinitionSource.Manual [] ]
                     []
-                    DateTimeOffset.UtcNow)
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error(CreateDraftEntryError.EntryTextTooLong MaxEntryTextLength), result)
     }
@@ -468,7 +473,10 @@ let ``returns error when both definitions and translations are empty``() =
                 createDefaultCollection = (fun _ -> failwith "Should not be called")
             )
 
-        let! result = create env (makeCreateParams (UserId 1) "test word" [] [] DateTimeOffset.UtcNow)
+        let! result =
+            create
+                env
+                (makeCreateParams (UserId 1) "test word" [] [] (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error CreateDraftEntryError.NoDefinitionsOrTranslations, result)
     }
@@ -476,7 +484,8 @@ let ``returns error when both definitions and translations are empty``() =
 [<Fact>]
 let ``returns error when duplicate entry exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingDefinition =
             makeDefinition 1 "existing definition" DefinitionSource.Manual 0 []
@@ -515,7 +524,8 @@ let ``returns error when duplicate entry exists``() =
 [<Fact>]
 let ``creates entry when duplicate exists and AllowDuplicate is true``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 1 "test word" now [] []
@@ -583,7 +593,15 @@ let ``returns error when example text is too long``() =
                 createDefaultCollection = (fun _ -> failwith "Should not be called")
             )
 
-        let! result = create env (makeCreateParams (UserId 1) "test word" definitionInputs [] DateTimeOffset.UtcNow)
+        let! result =
+            create
+                env
+                (makeCreateParams
+                    (UserId 1)
+                    "test word"
+                    definitionInputs
+                    []
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error(CreateDraftEntryError.ExampleTextTooLong MaxExampleTextLength), result)
     }
@@ -613,7 +631,15 @@ let ``returns error when too many examples in definition``() =
                 createDefaultCollection = (fun _ -> failwith "Should not be called")
             )
 
-        let! result = create env (makeCreateParams (UserId 1) "test word" definitionInputs [] DateTimeOffset.UtcNow)
+        let! result =
+            create
+                env
+                (makeCreateParams
+                    (UserId 1)
+                    "test word"
+                    definitionInputs
+                    []
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error(CreateDraftEntryError.TooManyExamples MaxExamplesPerItem), result)
     }
@@ -643,7 +669,15 @@ let ``returns error when too many examples in translation``() =
                 createDefaultCollection = (fun _ -> failwith "Should not be called")
             )
 
-        let! result = create env (makeCreateParams (UserId 1) "test word" [] translationInputs DateTimeOffset.UtcNow)
+        let! result =
+            create
+                env
+                (makeCreateParams
+                    (UserId 1)
+                    "test word"
+                    []
+                    translationInputs
+                    (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)))
 
         Assert.Equal(Error(CreateDraftEntryError.TooManyExamples MaxExamplesPerItem), result)
     }
@@ -651,7 +685,8 @@ let ``returns error when too many examples in translation``() =
 [<Fact>]
 let ``proceeds when duplicate text match finds a stale record``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let staleEntry =
             makeEntry 99 1 "test word" now [] []
@@ -693,7 +728,8 @@ let ``proceeds when duplicate text match finds a stale record``() =
 [<Fact>]
 let ``throws when post-create entry fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]
@@ -723,7 +759,8 @@ let ``throws when post-create entry fetch returns None``() =
 [<Fact>]
 let ``creates entry when default vocabulary does not exist but default collection does``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]
@@ -765,7 +802,8 @@ let ``creates entry when default vocabulary does not exist but default collectio
 [<Fact>]
 let ``creates entry when neither default vocabulary nor default collection exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitionInputs =
             [ makeDefinitionInput "A test definition" DefinitionSource.Manual [] ]

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/DeleteTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.DraftOperations.DeleteTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -51,7 +52,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByIdTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.DraftOperations.GetByIdTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -35,7 +36,8 @@ type TestEnv(getEntryById: EntryId -> Task<Entry option>, hasVocabularyAccess: H
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId entryText definitions translations =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/GetByVocabularyIdTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.DraftOperations.GetByVocabularyIdTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -40,7 +41,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/MoveTests.fs
@@ -64,7 +64,8 @@ let makeEntry id vocabularyId text createdAt updatedAt =
 [<Fact>]
 let ``moves entry when user has access to source and target vocabularies``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -137,7 +138,7 @@ let ``returns EntryNotFound when entry does not exist``() =
                 { UserId = UserId 1
                   EntryId = EntryId 99
                   TargetVocabularyId = VocabularyId 200
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveDraftEntryError.EntryNotFound(EntryId 99)), result)
         Assert.Empty(env.HasVocabularyAccessCalls)
@@ -148,7 +149,12 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when source vocabulary access is denied``() =
     task {
         let existingEntry =
-            makeEntry 10 100 "hello" DateTimeOffset.UtcNow DateTimeOffset.UtcNow
+            makeEntry
+                10
+                100
+                "hello"
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let accessCallCount = ref 0
 
@@ -173,7 +179,7 @@ let ``returns EntryNotFound when source vocabulary access is denied``() =
                 { UserId = UserId 1
                   EntryId = EntryId 10
                   TargetVocabularyId = VocabularyId 200
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveDraftEntryError.EntryNotFound(EntryId 10)), result)
 
@@ -191,7 +197,12 @@ let ``returns EntryNotFound when source vocabulary access is denied``() =
 let ``returns VocabularyNotFoundOrAccessDenied when target vocabulary access is denied``() =
     task {
         let existingEntry =
-            makeEntry 10 100 "hello" DateTimeOffset.UtcNow DateTimeOffset.UtcNow
+            makeEntry
+                10
+                100
+                "hello"
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let accessCallCount = ref 0
 
@@ -218,7 +229,7 @@ let ``returns VocabularyNotFoundOrAccessDenied when target vocabulary access is 
                 { UserId = UserId 1
                   EntryId = EntryId 10
                   TargetVocabularyId = VocabularyId 200
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveDraftEntryError.VocabularyNotFoundOrAccessDenied(VocabularyId 200)), result)
 
@@ -238,7 +249,8 @@ let ``returns VocabularyNotFoundOrAccessDenied when target vocabulary access is 
 [<Fact>]
 let ``throws when post-move entry fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -276,7 +288,8 @@ let ``throws when post-move entry fetch returns None``() =
 [<Fact>]
 let ``move succeeds without duplicate checks in target vocabulary``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "duplicate-text" now now

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/DraftOperations/UpdateTests.fs
@@ -158,7 +158,8 @@ let makeExampleInput text source = { ExampleText = text; Source = source }
 [<Fact>]
 let ``updates entry with new definitions and translations``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "old" [] [] now now
@@ -310,7 +311,7 @@ let ``returns EntryNotFound when entry does not exist``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.EntryNotFound(EntryId 99)), result)
         Assert.Equal<EntryId list>([ EntryId 99 ], env.GetEntryByIdCalls)
@@ -321,7 +322,14 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when user has no access``() =
     task {
         let entry =
-            makeEntry 1 10 "text" [] [] DateTimeOffset.UtcNow DateTimeOffset.UtcNow
+            makeEntry
+                1
+                10
+                "text"
+                []
+                []
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -346,7 +354,7 @@ let ``returns EntryNotFound when user has no access``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.EntryNotFound(EntryId 1)), result)
         Assert.Equal<EntryId list>([ EntryId 1 ], env.GetEntryByIdCalls)
@@ -384,7 +392,7 @@ let ``returns error when no definitions or translations``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateDraftEntryError.NoDefinitionsOrTranslations, result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -422,7 +430,7 @@ let ``returns error when example text is too long``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.ExampleTextTooLong MaxExampleTextLength), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -458,7 +466,7 @@ let ``returns error when too many examples``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.TooManyExamples MaxExamplesPerItem), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -490,7 +498,7 @@ let ``returns error when entry text is empty``() =
                   EntryText = ""
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateDraftEntryError.EntryTextRequired, result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -522,7 +530,7 @@ let ``returns error when entry text is whitespace only``() =
                   EntryText = "   "
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateDraftEntryError.EntryTextRequired, result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -557,7 +565,7 @@ let ``returns error when entry text exceeds max length``() =
                   EntryText = longText
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.EntryTextTooLong MaxEntryTextLength), result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -595,7 +603,7 @@ let ``returns error when translation example text is too long``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = translations
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.ExampleTextTooLong MaxExampleTextLength), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -631,7 +639,7 @@ let ``returns error when too many examples in translation``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = translations
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateDraftEntryError.TooManyExamples MaxExamplesPerItem), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -640,7 +648,8 @@ let ``returns error when too many examples in translation``() =
 [<Fact>]
 let ``updates entry with definitions only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "word" [] [] now now
@@ -706,7 +715,8 @@ let ``updates entry with definitions only``() =
 [<Fact>]
 let ``updates entry with translations only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "word" [] [] now now

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/CreateTests.fs
@@ -76,7 +76,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
-    let timestamp = DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId
@@ -133,7 +134,9 @@ let makeTranslation id text source displayOrder examples =
 [<Fact>]
 let ``creates entry when vocabulary is in collection``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let createdEntry = makeEntry 1 10 "hello"
 
         let definitions =
@@ -198,7 +201,7 @@ let ``returns VocabularyNotFoundOrAccessDenied when vocabulary is not in collect
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual [] ]
 
         let parameters =
-            makeParameters 1 10 "hello" definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "hello" definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -241,7 +244,9 @@ let ``returns VocabularyNotFoundOrAccessDenied when vocabulary is not in collect
 [<Fact>]
 let ``returns DuplicateEntry when entry text already exists in vocabulary``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let duplicateEntry = makeEntry 99 10 "hello"
 
         let definitions =
@@ -302,7 +307,9 @@ let ``returns DuplicateEntry when entry text already exists in vocabulary``() =
 [<Fact>]
 let ``creates entry when AllowDuplicate is true even if duplicate exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let createdEntry = makeEntry 2 10 "hello"
 
         let definitions =
@@ -358,7 +365,7 @@ let ``creates entry when AllowDuplicate is true even if duplicate exists``() =
 let ``returns NoDefinitionsOrTranslations when both lists are empty``() =
     task {
         let parameters =
-            makeParameters 1 10 "hello" [] [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "hello" [] [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -397,7 +404,7 @@ let ``returns EntryTextRequired when entry text is empty``() =
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual [] ]
 
         let parameters =
-            makeParameters 1 10 "" definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "" definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -439,7 +446,7 @@ let ``returns EntryTextTooLong when entry text exceeds max length``() =
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual [] ]
 
         let parameters =
-            makeParameters 1 10 longText definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 longText definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -484,7 +491,7 @@ let ``returns ExampleTextTooLong when definition example text exceeds max length
                   [ makeExampleInput longExample ExampleSource.Custom ] ]
 
         let parameters =
-            makeParameters 1 10 "hello" definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "hello" definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -519,7 +526,8 @@ let ``returns ExampleTextTooLong when definition example text exceeds max length
 [<Fact>]
 let ``creates entry with translations only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let expectedTranslation =
             makeTranslation 1 "hello in spanish" TranslationSource.Manual 0 []
@@ -580,7 +588,8 @@ let ``creates entry with translations only``() =
 [<Fact>]
 let ``creates entry with both definitions and translations``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let expectedDefinition =
             makeDefinition 10 "a greeting" DefinitionSource.Manual 0 []
@@ -647,7 +656,9 @@ let ``creates entry with both definitions and translations``() =
 [<Fact>]
 let ``trims whitespace from entry text``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let createdEntry = makeEntry 1 10 "hello"
 
         let definitions =
@@ -715,7 +726,7 @@ let ``returns EntryTextRequired when entry text is whitespace only``() =
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual [] ]
 
         let parameters =
-            makeParameters 1 10 "   " definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "   " definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -758,7 +769,7 @@ let ``returns TooManyExamples when definition has too many examples``() =
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual examples ]
 
         let parameters =
-            makeParameters 1 10 "hello" definitions [] false DateTimeOffset.UtcNow
+            makeParameters 1 10 "hello" definitions [] false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -801,7 +812,7 @@ let ``returns TooManyExamples when translation has too many examples``() =
             [ makeTranslationInput "hola" TranslationSource.Manual examples ]
 
         let parameters =
-            makeParameters 1 10 "hello" [] translations false DateTimeOffset.UtcNow
+            makeParameters 1 10 "hello" [] translations false (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -836,7 +847,9 @@ let ``returns TooManyExamples when translation has too many examples``() =
 [<Fact>]
 let ``proceeds when duplicate text match finds a stale record``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let staleEntry = makeEntry 99 10 "hello"
         let createdEntry = makeEntry 1 10 "hello"
 
@@ -898,7 +911,8 @@ let ``proceeds when duplicate text match finds a stale record``() =
 [<Fact>]
 let ``throws when post-create entry fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let definitions =
             [ makeDefinitionInput "a greeting" DefinitionSource.Manual [] ]

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/DeleteTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.EntryOperations.DeleteTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -52,7 +53,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByIdTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.EntryOperations.GetByIdTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -40,7 +41,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId entryText =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/GetByVocabularyIdTests.fs
@@ -1,5 +1,6 @@
 module Wordfolio.Api.Domain.Tests.Entries.EntryOperations.GetByVocabularyIdTests
 
+open System
 open System.Threading.Tasks
 
 open Xunit
@@ -41,7 +42,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeEntry id vocabularyId text =
-    let timestamp = System.DateTimeOffset.UtcNow
+    let timestamp =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = EntryId id
       VocabularyId = VocabularyId vocabularyId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/MoveTests.fs
@@ -125,7 +125,8 @@ let makeEntry id vocabularyId text createdAt updatedAt =
       Translations = [] }
 
 let makeCollection id userId : Collection =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -145,7 +146,8 @@ let makeVocabulary id collectionId createdAt : Vocabulary =
 [<Fact>]
 let ``moves entry when explicit target vocabulary is accessible``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -222,7 +224,8 @@ let ``moves entry when explicit target vocabulary is accessible``() =
 [<Fact>]
 let ``moves entry to existing default vocabulary when target vocabulary id is None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -297,7 +300,8 @@ let ``moves entry to existing default vocabulary when target vocabulary id is No
 [<Fact>]
 let ``creates default vocabulary when target vocabulary id is None and default collection exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -381,7 +385,8 @@ let ``creates default vocabulary when target vocabulary id is None and default c
 [<Fact>]
 let ``creates default collection and vocabulary when target vocabulary id is None and neither exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -492,7 +497,7 @@ let ``returns VocabularyNotFoundOrAccessDenied when source vocabulary is not in 
                   VocabularyId = VocabularyId 100
                   EntryId = EntryId 10
                   TargetVocabularyId = Some(VocabularyId 200)
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveEntryError.VocabularyNotFoundOrAccessDenied(VocabularyId 100)), result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -527,7 +532,7 @@ let ``returns EntryNotFound when entry does not exist``() =
                   VocabularyId = VocabularyId 100
                   EntryId = EntryId 99
                   TargetVocabularyId = Some(VocabularyId 200)
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveEntryError.EntryNotFound(EntryId 99)), result)
         Assert.Equal<EntryId list>([ EntryId 99 ], env.GetEntryByIdCalls)
@@ -542,7 +547,8 @@ let ``returns EntryNotFound when entry does not exist``() =
 [<Fact>]
 let ``returns EntryNotFound when entry belongs to different vocabulary``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let entry = makeEntry 10 999 "hello" now now
 
@@ -581,7 +587,8 @@ let ``returns EntryNotFound when entry belongs to different vocabulary``() =
 [<Fact>]
 let ``returns VocabularyNotFoundOrAccessDenied when explicit target vocabulary access is denied``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -628,7 +635,8 @@ let ``returns VocabularyNotFoundOrAccessDenied when explicit target vocabulary a
 [<Fact>]
 let ``throws when post-move entry fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "hello" now now
@@ -673,7 +681,8 @@ let ``throws when post-move entry fetch returns None``() =
 [<Fact>]
 let ``move succeeds without duplicate checks in explicit target vocabulary``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 10 100 "duplicate-text" now now

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Entries/EntryOperations/UpdateTests.fs
@@ -159,7 +159,8 @@ let makeExampleInput text source = { ExampleText = text; Source = source }
 [<Fact>]
 let ``updates entry with new definitions and translations``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "old" [] [] now now
@@ -316,7 +317,7 @@ let ``returns VocabularyNotFoundOrAccessDenied when vocabulary is not in collect
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.VocabularyNotFoundOrAccessDenied(VocabularyId 10)), result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -359,7 +360,7 @@ let ``returns EntryNotFound when entry does not exist``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.EntryNotFound(EntryId 99)), result)
         Assert.Equal<EntryId list>([ EntryId 99 ], env.GetEntryByIdCalls)
@@ -370,7 +371,14 @@ let ``returns EntryNotFound when entry does not exist``() =
 let ``returns EntryNotFound when entry belongs to different vocabulary``() =
     task {
         let entry =
-            makeEntry 1 99 "text" [] [] DateTimeOffset.UtcNow DateTimeOffset.UtcNow
+            makeEntry
+                1
+                99
+                "text"
+                []
+                []
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
+                (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero))
 
         let env =
             TestEnv(
@@ -397,7 +405,7 @@ let ``returns EntryNotFound when entry belongs to different vocabulary``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.EntryNotFound(EntryId 1)), result)
         Assert.Equal<EntryId list>([ EntryId 1 ], env.GetEntryByIdCalls)
@@ -429,7 +437,7 @@ let ``returns error when no definitions or translations``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateEntryError.NoDefinitionsOrTranslations, result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -463,7 +471,7 @@ let ``returns error when entry text is empty``() =
                   EntryText = ""
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateEntryError.EntryTextRequired, result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -500,7 +508,7 @@ let ``returns error when entry text exceeds max length``() =
                   EntryText = longText
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.EntryTextTooLong MaxEntryTextLength), result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -534,7 +542,7 @@ let ``returns error when entry text is whitespace only``() =
                   EntryText = "   "
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateEntryError.EntryTextRequired, result)
         Assert.Empty(env.GetEntryByIdCalls)
@@ -574,7 +582,7 @@ let ``returns error when definition example text is too long``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.ExampleTextTooLong MaxExampleTextLength), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -612,7 +620,7 @@ let ``returns error when definition has too many examples``() =
                   EntryText = "text"
                   Definitions = definitions
                   Translations = []
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.TooManyExamples MaxExamplesPerItem), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -652,7 +660,7 @@ let ``returns error when translation example text is too long``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = translations
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.ExampleTextTooLong MaxExampleTextLength), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -690,7 +698,7 @@ let ``returns error when translation has too many examples``() =
                   EntryText = "text"
                   Definitions = []
                   Translations = translations
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateEntryError.TooManyExamples MaxExamplesPerItem), result)
         Assert.Empty(env.UpdateEntryCalls)
@@ -699,7 +707,8 @@ let ``returns error when translation has too many examples``() =
 [<Fact>]
 let ``updates entry with definitions only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "word" [] [] now now
@@ -766,7 +775,8 @@ let ``updates entry with definitions only``() =
 [<Fact>]
 let ``updates entry with translations only``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingEntry =
             makeEntry 1 10 "word" [] [] now now

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/GetOrCreateDefaultVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/GetOrCreateDefaultVocabularyTests.fs
@@ -62,7 +62,8 @@ type TestEnv
             createDefaultCollection parameters
 
 let makeCollection id userId : Collection =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -82,7 +83,8 @@ let makeVocabulary id collectionId createdAt : Vocabulary =
 [<Fact>]
 let ``returns existing default vocabulary id when it exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingVocabulary =
             makeVocabulary 1 1 now
@@ -107,7 +109,9 @@ let ``returns existing default vocabulary id when it exists``() =
 [<Fact>]
 let ``creates vocabulary when collection exists but vocabulary does not``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
 
         let expectedVocabularyParams: CreateDefaultVocabularyParameters =
@@ -141,7 +145,8 @@ let ``creates vocabulary when collection exists but vocabulary does not``() =
 [<Fact>]
 let ``creates both collection and vocabulary when neither exists``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let expectedCollectionParams: CreateDefaultCollectionParameters =
             { UserId = UserId 1

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/CreateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/CreateTests.fs
@@ -53,7 +53,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -73,7 +74,9 @@ let makeVocabulary id collectionId name description createdAt =
 [<Fact>]
 let ``creates vocabulary with valid name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
 
         let createdVocabulary =
@@ -136,7 +139,9 @@ let ``creates vocabulary with valid name``() =
 [<Fact>]
 let ``creates vocabulary with description``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
         let description = Some "A test description"
 
@@ -181,7 +186,9 @@ let ``creates vocabulary with description``() =
 [<Fact>]
 let ``trims whitespace from name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
 
         let createdVocabulary =
@@ -241,7 +248,7 @@ let ``returns CollectionNotFound when collection does not exist``() =
                   CollectionId = CollectionId 1
                   Name = "Test Vocabulary"
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(CreateVocabularyError.VocabularyCollectionNotFound(CollectionId 1)), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -268,7 +275,7 @@ let ``returns CollectionNotFound when collection owned by different user``() =
                   CollectionId = CollectionId 1
                   Name = "Test Vocabulary"
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(CreateVocabularyError.VocabularyCollectionNotFound(CollectionId 1)), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -295,7 +302,7 @@ let ``returns error when name is empty``() =
                   CollectionId = CollectionId 1
                   Name = ""
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error CreateVocabularyError.VocabularyNameRequired, result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -322,7 +329,7 @@ let ``returns error when name is whitespace only``() =
                   CollectionId = CollectionId 1
                   Name = "   "
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error CreateVocabularyError.VocabularyNameRequired, result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -350,7 +357,7 @@ let ``returns error when name exceeds max length``() =
                   CollectionId = CollectionId 1
                   Name = longName
                   Description = None
-                  CreatedAt = DateTimeOffset.UtcNow }
+                  CreatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(CreateVocabularyError.VocabularyNameTooLong MaxNameLength), result)
         Assert.Equal<CollectionId list>([ CollectionId 1 ], env.GetCollectionByIdCalls)
@@ -361,7 +368,9 @@ let ``returns error when name exceeds max length``() =
 [<Fact>]
 let ``accepts name at exact max length``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
 
         let maxLengthName =
@@ -408,7 +417,9 @@ let ``accepts name at exact max length``() =
 [<Fact>]
 let ``throws when post-creation vocabulary fetch returns None``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
+
         let collection = makeCollection 1 1
 
         let env =

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/DeleteTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/DeleteTests.fs
@@ -53,7 +53,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -63,7 +64,8 @@ let makeCollection id userId =
       UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByCollectionIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByCollectionIdTests.fs
@@ -42,7 +42,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -52,7 +53,8 @@ let makeCollection id userId =
       UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/GetByIdTests.fs
@@ -41,7 +41,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -51,7 +52,8 @@ let makeCollection id userId =
       UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/MoveTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/MoveTests.fs
@@ -54,7 +54,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -64,7 +65,8 @@ let makeCollection id userId =
       UpdatedAt = createdAt }
 
 let makeVocabulary id collectionId name =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
@@ -76,7 +78,8 @@ let makeVocabulary id collectionId name =
 [<Fact>]
 let ``moves vocabulary when both collections are owned and vocabulary is in source``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let sourceCollection = makeCollection 10 1
         let targetCollection = makeCollection 20 1
@@ -159,7 +162,7 @@ let ``returns CollectionNotFoundOrAccessDenied when source collection belongs to
                   CollectionId = CollectionId 10
                   VocabularyId = VocabularyId 5
                   TargetCollectionId = CollectionId 20
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveVocabularyError.CollectionNotFoundOrAccessDenied(CollectionId 10)), result)
 
@@ -185,7 +188,7 @@ let ``returns CollectionNotFoundOrAccessDenied when source collection does not e
                   CollectionId = CollectionId 10
                   VocabularyId = VocabularyId 5
                   TargetCollectionId = CollectionId 20
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveVocabularyError.CollectionNotFoundOrAccessDenied(CollectionId 10)), result)
 
@@ -216,7 +219,7 @@ let ``returns VocabularyNotFound when vocabulary is not in source collection``()
                   CollectionId = CollectionId 10
                   VocabularyId = VocabularyId 5
                   TargetCollectionId = CollectionId 20
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveVocabularyError.VocabularyNotFound(VocabularyId 5)), result)
 
@@ -255,7 +258,7 @@ let ``returns CollectionNotFoundOrAccessDenied when target collection belongs to
                   CollectionId = CollectionId 10
                   VocabularyId = VocabularyId 5
                   TargetCollectionId = CollectionId 20
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveVocabularyError.CollectionNotFoundOrAccessDenied(CollectionId 20)), result)
 
@@ -291,7 +294,7 @@ let ``returns CollectionNotFoundOrAccessDenied when target collection does not e
                   CollectionId = CollectionId 10
                   VocabularyId = VocabularyId 5
                   TargetCollectionId = CollectionId 20
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(MoveVocabularyError.CollectionNotFoundOrAccessDenied(CollectionId 20)), result)
 
@@ -303,7 +306,8 @@ let ``returns CollectionNotFoundOrAccessDenied when target collection does not e
 [<Fact>]
 let ``returns VocabularyNotFound when move capability returns Error``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let sourceCollection = makeCollection 10 1
         let targetCollection = makeCollection 20 1

--- a/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/UpdateTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain.Tests/Vocabularies/UpdateTests.fs
@@ -53,7 +53,8 @@ type TestEnv
         member this.RunInTransaction(operation) = operation this
 
 let makeCollection id userId =
-    let createdAt = DateTimeOffset.UtcNow
+    let createdAt =
+        DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
     { Id = CollectionId id
       UserId = UserId userId
@@ -64,7 +65,7 @@ let makeCollection id userId =
 
 let makeVocabulary id collectionId name description =
     let createdAt =
-        DateTimeOffset.UtcNow.AddDays(-1)
+        (DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)).AddDays(-1)
 
     { Id = VocabularyId id
       CollectionId = CollectionId collectionId
@@ -76,7 +77,8 @@ let makeVocabulary id collectionId name description =
 [<Fact>]
 let ``updates vocabulary when collection owned by user``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingVocabulary =
             makeVocabulary 1 1 "Old Name" None
@@ -149,7 +151,8 @@ let ``updates vocabulary when collection owned by user``() =
 [<Fact>]
 let ``trims whitespace from name``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingVocabulary =
             makeVocabulary 1 1 "Old Name" None
@@ -212,7 +215,7 @@ let ``returns NotFound when vocabulary does not exist``() =
                   VocabularyId = VocabularyId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateVocabularyError.VocabularyNotFound(VocabularyId 1)), result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -241,7 +244,7 @@ let ``returns NotFound when vocabulary belongs to different collection``() =
                   VocabularyId = VocabularyId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateVocabularyError.VocabularyNotFound(VocabularyId 1)), result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -272,7 +275,7 @@ let ``returns AccessDenied when collection owned by different user``() =
                   VocabularyId = VocabularyId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateVocabularyError.VocabularyAccessDenied(VocabularyId 1)), result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -301,7 +304,7 @@ let ``returns AccessDenied when collection does not exist``() =
                   VocabularyId = VocabularyId 1
                   Name = "New Name"
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateVocabularyError.VocabularyAccessDenied(VocabularyId 1)), result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -332,7 +335,7 @@ let ``returns error when name is empty``() =
                   VocabularyId = VocabularyId 1
                   Name = ""
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateVocabularyError.VocabularyNameRequired, result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -364,7 +367,7 @@ let ``returns error when name exceeds max length``() =
                   VocabularyId = VocabularyId 1
                   Name = longName
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error(UpdateVocabularyError.VocabularyNameTooLong MaxNameLength), result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -395,7 +398,7 @@ let ``returns error when name is whitespace only``() =
                   VocabularyId = VocabularyId 1
                   Name = "   "
                   Description = None
-                  UpdatedAt = DateTimeOffset.UtcNow }
+                  UpdatedAt = DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) }
 
         Assert.Equal(Error UpdateVocabularyError.VocabularyNameRequired, result)
         Assert.Equal<VocabularyId list>([ VocabularyId 1 ], env.GetVocabularyByIdCalls)
@@ -406,7 +409,8 @@ let ``returns error when name is whitespace only``() =
 [<Fact>]
 let ``accepts name at exact max length``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingVocabulary =
             makeVocabulary 1 1 "Old Name" None
@@ -454,7 +458,8 @@ let ``accepts name at exact max length``() =
 [<Fact>]
 let ``returns NotFound when update affects no rows``() =
     task {
-        let now = DateTimeOffset.UtcNow
+        let now =
+            DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)
 
         let existingVocabulary =
             makeVocabulary 1 1 "Test Vocabulary" None

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
@@ -100,7 +100,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
                 factory.CreateUserAsync(106, "requester@example.com", "P@ssw0rd!")
 
             let ownerCollection =
-                let createdAt = DateTimeOffset.UtcNow
+                let createdAt =
+                    DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
                 Entities.makeCollection
                     ownerWordfolioUser

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
@@ -27,7 +27,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(105, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Original Name" (Some "Original Description") now now false
@@ -170,7 +171,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(108, "requester@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let ownerCollection =
                 Entities.makeCollection ownerWordfolioUser "Owner Collection" (Some "Owner Description") now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
@@ -215,7 +215,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let regularCollection =
                 Entities.makeCollection wordfolioUser "Regular Collection" None now now false
@@ -264,7 +265,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -410,7 +412,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(305, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let systemCollection =
                 Entities.makeCollection wordfolioUser "Unsorted" None now now true

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
@@ -135,11 +135,15 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser, wordfolioUser = factory.CreateUserAsync(318, "user@example.com", "P@ssw0rd!")
 
             let collection =
-                let createdAt = DateTimeOffset.UtcNow
+                let createdAt =
+                    DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
                 Entities.makeCollection wordfolioUser "System Collection" None createdAt createdAt true
 
             let vocabulary =
-                let createdAt = DateTimeOffset.UtcNow
+                let createdAt =
+                    DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
+
                 Entities.makeVocabulary collection "Vocab" None createdAt createdAt false
 
             do!

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
@@ -104,7 +104,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(401, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let systemCollection =
                 Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
@@ -511,7 +512,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(604, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let systemCollection =
                 Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true
@@ -556,7 +558,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(605, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let systemCollection =
                 Entities.makeCollection wordfolioUser "[System] Unsorted" None now now true

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
@@ -25,7 +25,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(706, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -85,7 +86,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(707, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -158,7 +160,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(715, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(716, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
@@ -232,7 +235,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
@@ -245,7 +245,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(718, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(719, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection1 =
                 Entities.makeCollection wordfolioUser1 "Collection 1" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
@@ -384,7 +384,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(704, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -572,7 +573,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(713, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(714, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser1 "Test Collection" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
@@ -28,7 +28,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -163,7 +164,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(320, "auth-required@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Auth Collection" None now now false
@@ -219,7 +221,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -278,7 +281,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(322, "owner@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let ownerCollection =
                 Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
@@ -345,7 +349,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -386,7 +391,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(303, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -442,7 +448,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -490,7 +497,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(319, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -609,7 +617,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -650,7 +659,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(517, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
@@ -27,7 +27,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(402, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -88,7 +89,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(403, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -163,7 +165,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! _, wordfolioUser1 = factory.CreateUserAsync(405, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(406, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
@@ -238,7 +241,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(407, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -314,7 +318,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(510, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -350,7 +355,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(514, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -389,7 +395,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(521, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
@@ -27,7 +27,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(308, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -95,7 +96,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(309, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -182,7 +184,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, otherWordfolioUser = factory.CreateUserAsync(312, "other@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let requesterCollection =
                 Entities.makeCollection requesterWordfolioUser "Requester Collection" None now now false
@@ -224,7 +227,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -256,7 +260,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(516, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
@@ -158,7 +158,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(521, "requester@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let ownerCollection =
                 Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
@@ -212,7 +213,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -248,7 +250,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(512, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -287,7 +290,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(518, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -323,7 +327,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(519, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
@@ -891,7 +891,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(515, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -934,7 +935,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(522, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
@@ -455,7 +455,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(313, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -665,7 +666,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(317, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(318, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser1 "Test Collection" None now now false
@@ -843,7 +845,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(509, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -887,7 +890,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(513, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -935,7 +939,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(520, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
@@ -25,7 +25,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -68,7 +69,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(209, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -99,7 +101,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(218, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
@@ -27,7 +27,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "My Collection" None now now false
@@ -90,7 +91,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -148,7 +150,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(210, "requester@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let ownerCollection =
                 Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
@@ -27,7 +27,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(600, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let createdAt =
                 DateTimeOffset(2026, 1, 10, 10, 0, 0, TimeSpan.Zero)
@@ -139,7 +140,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(601, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Collection" None now now false
@@ -170,7 +172,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(602, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Collection" None now now false
@@ -206,7 +209,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(603, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false
@@ -262,7 +266,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(604, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(605, "user2@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let sourceCollection =
                 Entities.makeCollection wordfolioUser1 "Source" None now now false

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
@@ -126,7 +126,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(206, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -165,7 +166,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(217, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collectionA =
                 Entities.makeCollection wordfolioUser "Collection A" None now now false
@@ -235,7 +237,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(214, "requester@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let ownerCollection =
                 Entities.makeCollection ownerWordfolioUser "Owner Collection" None now now false
@@ -324,7 +327,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(207, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false
@@ -382,7 +386,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let! _, wordfolioUser = factory.CreateUserAsync(215, "user@example.com", "P@ssw0rd!")
 
-            let now = DateTimeOffset.UtcNow
+            let now =
+                DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)
 
             let collection =
                 Entities.makeCollection wordfolioUser "Test Collection" None now now false


### PR DESCRIPTION
## Summary
- Replace `DateTimeOffset.UtcNow` with fixed, deterministic dates (`DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero)`) across all domain and data access tests

## Test plan
- [ ] All existing tests pass with the fixed dates
- [ ] No flaky timing-dependent assertions remain