### PR TITLE
Auto-login after registration

### DIFF
--- a/Wordfolio.Frontend/src/features/auth/hooks/useRegisterMutation.ts
+++ b/Wordfolio.Frontend/src/features/auth/hooks/useRegisterMutation.ts
@@ -2,11 +2,15 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import type { ApiError } from "../../../shared/api/types/entries";
 import { authApi } from "../api/authApi";
-import { mapRegisterRequest } from "../api/mappers";
-import type { RegisterCredentials } from "../types";
+import {
+    mapAuthTokens,
+    mapLoginRequest,
+    mapRegisterRequest,
+} from "../api/mappers";
+import type { AuthTokens, RegisterCredentials } from "../types";
 
 interface UseRegisterMutationOptions {
-    readonly onSuccess?: () => Promise<void>;
+    readonly onSuccess?: (data: AuthTokens) => Promise<void>;
     readonly onError?: (error: ApiError) => void;
 }
 
@@ -14,11 +18,17 @@ export function useRegisterMutation(options?: UseRegisterMutationOptions) {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: async (credentials: RegisterCredentials) => {
+        mutationFn: async (
+            credentials: RegisterCredentials
+        ): Promise<AuthTokens> => {
             await authApi.register(mapRegisterRequest(credentials));
+            const loginResponse = await authApi.login(
+                mapLoginRequest(credentials)
+            );
+            return mapAuthTokens(loginResponse);
         },
-        onSuccess: async () => {
-            await options?.onSuccess?.();
+        onSuccess: async (data) => {
+            await options?.onSuccess?.(data);
             void queryClient.invalidateQueries();
         },
         onError: options?.onError,

--- a/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
@@ -10,6 +10,7 @@ import {
     Typography,
 } from "@mui/material";
 
+import { useAuthStore } from "../../../shared/stores/authStore";
 import { ContentSkeleton } from "../../../shared/components/ContentSkeleton";
 import { PasswordField } from "../../../shared/components/PasswordField";
 import { RetryOnError } from "../../../shared/components/RetryOnError";
@@ -18,7 +19,7 @@ import { SignalApertureDialogPaper } from "../components/SignalApertureDialogPap
 import { useRegisterMutation } from "../hooks/useRegisterMutation";
 import { usePasswordRequirementsQuery } from "../hooks/usePasswordRequirementsQuery";
 import { parseApiError } from "../errorHandling";
-import { loginPath, registerRouteApi } from "../routes";
+import { loginPath, homePath, registerRouteApi } from "../routes";
 import { getSafeRedirectPath } from "../../../shared/utils/redirectUtils";
 import {
     createRegisterSchema,
@@ -34,6 +35,7 @@ export const RegisterPage = () => {
     const loginNavigation = safeRedirect
         ? loginPath({ redirect: safeRedirect })
         : loginPath();
+    const setTokens = useAuthStore((state) => state.setTokens);
     const {
         data: passwordRequirements,
         isLoading: isLoadingRequirements,
@@ -53,11 +55,13 @@ export const RegisterPage = () => {
     });
 
     const registerMutation = useRegisterMutation({
-        onSuccess: async () => {
-            await navigate({
-                ...loginNavigation,
-                replace: true,
-            });
+        onSuccess: async (data) => {
+            setTokens(data);
+            const destination = getSafeRedirectPath(
+                safeRedirect,
+                homePath().to
+            );
+            await navigate({ to: destination, replace: true });
         },
         onError: (error) => {
             const errorMessages = parseApiError(error);

--- a/Wordfolio.Frontend/tests/features/auth/hooks/useRegisterMutation.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/hooks/useRegisterMutation.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+
+import { useRegisterMutation } from "../../../../src/features/auth/hooks/useRegisterMutation";
+import * as authApi from "../../../../src/features/auth/api/authApi";
+
+vi.mock("@tanstack/react-router", () => ({
+    useNavigate: () => vi.fn(),
+    getRouteApi: () => ({}),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+const mockLoginResponse = {
+    tokenType: "Bearer",
+    accessToken: "access-token",
+    expiresIn: 3600,
+    refreshToken: "refresh-token",
+};
+
+const expectedTokens = {
+    tokenType: "Bearer",
+    accessToken: "access-token",
+    expiresIn: 3600,
+    refreshToken: "refresh-token",
+};
+
+const credentials = { email: "user@example.com", password: "Password1!" };
+
+describe("useRegisterMutation", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("calls register then login on success and returns tokens", async () => {
+        const registerSpy = vi
+            .spyOn(authApi.authApi, "register")
+            .mockResolvedValue(undefined);
+        const loginSpy = vi
+            .spyOn(authApi.authApi, "login")
+            .mockResolvedValue(mockLoginResponse);
+
+        const onSuccess = vi.fn().mockResolvedValue(undefined);
+
+        const { result } = renderHook(
+            () => useRegisterMutation({ onSuccess }),
+            { wrapper: createWrapper() }
+        );
+
+        await act(async () => {
+            result.current.mutate(credentials);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.isSuccess).toBe(true);
+        });
+
+        expect(registerSpy).toHaveBeenCalledWith({
+            email: credentials.email,
+            password: credentials.password,
+        });
+        expect(loginSpy).toHaveBeenCalledWith({
+            email: credentials.email,
+            password: credentials.password,
+        });
+        expect(onSuccess).toHaveBeenCalledWith(expectedTokens);
+        expect(result.current.data).toEqual(expectedTokens);
+    });
+
+    it("propagates register failure and does not call login", async () => {
+        const registerError = { status: 400, errors: ["Email already taken"] };
+        vi.spyOn(authApi.authApi, "register").mockRejectedValue(registerError);
+        const loginSpy = vi.spyOn(authApi.authApi, "login");
+
+        const onError = vi.fn();
+
+        const { result } = renderHook(() => useRegisterMutation({ onError }), {
+            wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+            result.current.mutate(credentials);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.isError).toBe(true);
+        });
+
+        expect(loginSpy).not.toHaveBeenCalled();
+        expect(onError.mock.calls[0][0]).toEqual(registerError);
+    });
+
+    it("propagates login failure after successful register", async () => {
+        vi.spyOn(authApi.authApi, "register").mockResolvedValue(undefined);
+        const loginError = { status: 401, errors: ["Unauthorized"] };
+        vi.spyOn(authApi.authApi, "login").mockRejectedValue(loginError);
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        const { result } = renderHook(
+            () => useRegisterMutation({ onSuccess, onError }),
+            { wrapper: createWrapper() }
+        );
+
+        await act(async () => {
+            result.current.mutate(credentials);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.isError).toBe(true);
+        });
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError.mock.calls[0][0]).toEqual(loginError);
+    });
+});

--- a/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { RegisterPage } from "../../../../src/features/auth/pages/RegisterPage";
+
+const mockNavigate = vi.fn();
+const mockSetTokens = vi.fn();
+
+const mockPasswordRequirements = {
+    requiredLength: 6,
+    requireDigit: false,
+    requireLowercase: false,
+    requireUppercase: false,
+    requireNonAlphanumeric: false,
+    requiredUniqueChars: 1,
+};
+
+const mockTokens = {
+    tokenType: "Bearer",
+    accessToken: "access-token",
+    expiresIn: 3600,
+    refreshToken: "refresh-token",
+};
+
+let mockSearchParams: { redirect?: string } = {};
+let mockRegisterMutate = vi.fn();
+let mockRegisterIsPending = false;
+let mockRegisterOnSuccess:
+    | ((data: typeof mockTokens) => Promise<void>)
+    | undefined;
+
+vi.mock("@tanstack/react-router", () => ({
+    useNavigate: () => mockNavigate,
+    getRouteApi: () => ({
+        useSearch: () => mockSearchParams,
+    }),
+    Link: ({
+        children,
+        to,
+        search,
+    }: {
+        to: string;
+        search?: Record<string, string>;
+        children: ReactNode;
+    }) => (
+        <a
+            href={
+                to +
+                (search ? "?" + new URLSearchParams(search).toString() : "")
+            }
+        >
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("../../../../src/features/auth/hooks/useRegisterMutation", () => ({
+    useRegisterMutation: (options?: {
+        onSuccess?: (data: typeof mockTokens) => Promise<void>;
+    }) => {
+        mockRegisterOnSuccess = options?.onSuccess;
+        return {
+            mutate: mockRegisterMutate,
+            isPending: mockRegisterIsPending,
+        };
+    },
+}));
+
+vi.mock(
+    "../../../../src/features/auth/hooks/usePasswordRequirementsQuery",
+    () => ({
+        usePasswordRequirementsQuery: () => ({
+            data: mockPasswordRequirements,
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        }),
+    })
+);
+
+vi.mock("../../../../src/shared/stores/authStore", () => ({
+    useAuthStore: vi.fn(
+        (selector: (state: { setTokens: typeof mockSetTokens }) => unknown) =>
+            selector({ setTokens: mockSetTokens })
+    ),
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+        },
+    });
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+describe("RegisterPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSearchParams = {};
+        mockRegisterMutate = vi.fn();
+        mockRegisterIsPending = false;
+        mockRegisterOnSuccess = undefined;
+    });
+
+    it("stores tokens and navigates home when no redirect is present", async () => {
+        mockSearchParams = {};
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        await act(async () => {
+            await mockRegisterOnSuccess?.(mockTokens);
+        });
+
+        expect(mockSetTokens).toHaveBeenCalledWith(mockTokens);
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: "/",
+            replace: true,
+        });
+    });
+
+    it("stores tokens and navigates to redirect destination on success", async () => {
+        mockSearchParams = { redirect: "/dashboard" };
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        await act(async () => {
+            await mockRegisterOnSuccess?.(mockTokens);
+        });
+
+        expect(mockSetTokens).toHaveBeenCalledWith(mockTokens);
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: "/dashboard",
+            replace: true,
+        });
+    });
+
+    it("footer login link preserves redirect query parameter", () => {
+        mockSearchParams = { redirect: "/dashboard" };
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        const loginLink = screen.getByRole("link", { name: /login here/i });
+        expect(loginLink.getAttribute("href")).toContain("redirect=");
+        expect(loginLink.getAttribute("href")).toContain("dashboard");
+    });
+
+    it("footer login link works without redirect parameter", () => {
+        mockSearchParams = {};
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        const loginLink = screen.getByRole("link", { name: /login here/i });
+        expect(loginLink.getAttribute("href")).toBe("/login");
+    });
+
+    it("submits registration form with entered credentials", async () => {
+        const user = userEvent.setup();
+        mockSearchParams = {};
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        await user.type(screen.getByLabelText(/email/i), "test@example.com");
+        await user.type(screen.getByLabelText(/^password$/i), "password123");
+        await user.type(
+            screen.getByLabelText(/confirm password/i),
+            "password123"
+        );
+        await user.click(
+            screen.getByRole("button", { name: /create archive/i })
+        );
+
+        expect(mockRegisterMutate).toHaveBeenCalledWith({
+            email: "test@example.com",
+            password: "password123",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- After successful registration, automatically log the user in by sequentially calling the register and login endpoints
- Store the returned auth tokens in the Zustand auth store and navigate directly to the home page (or redirect destination) instead of sending the user back to the login page
- Updated `useRegisterMutation` to expose `AuthTokens` from its `onSuccess` callback, and updated `RegisterPage` to consume them

## Test plan

- [ ] Register a new account — should land on the home page without visiting the login screen
- [ ] Register with a `?redirect=` param — should land on the redirect destination after registration
- [ ] Verify existing login flow is unaffected
- [ ] `useRegisterMutation` unit tests: register+login sequence, register failure skips login, login failure propagates correctly
- [ ] `RegisterPage` unit tests: tokens stored and navigation triggered correctly with and without redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)