### PR TITLE
fix: skip password toggle buttons in tab navigation

### DIFF
--- a/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
+++ b/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
@@ -458,7 +458,10 @@ export const DesignSystemPage = () => {
                                     input: {
                                         endAdornment: (
                                             <InputAdornment position="end">
-                                                <IconButton edge="end">
+                                                <IconButton
+                                                    edge="end"
+                                                    tabIndex={-1}
+                                                >
                                                     <Visibility />
                                                 </IconButton>
                                             </InputAdornment>
@@ -499,7 +502,10 @@ export const DesignSystemPage = () => {
                                     input: {
                                         endAdornment: (
                                             <InputAdornment position="end">
-                                                <IconButton edge="end">
+                                                <IconButton
+                                                    edge="end"
+                                                    tabIndex={-1}
+                                                >
                                                     <Visibility />
                                                 </IconButton>
                                             </InputAdornment>

--- a/Wordfolio.Frontend/src/shared/components/PasswordField.tsx
+++ b/Wordfolio.Frontend/src/shared/components/PasswordField.tsx
@@ -22,6 +22,7 @@ export const PasswordField = (props: PasswordFieldProps) => {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 onMouseDown={(e) => e.preventDefault()}
                                 edge="end"
+                                tabIndex={-1}
                             >
                                 {showPassword ? (
                                     <VisibilityOff />

--- a/Wordfolio.Frontend/tests/shared/components/PasswordField.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/PasswordField.test.tsx
@@ -56,6 +56,14 @@ describe("PasswordField", () => {
         ).toBeInTheDocument();
     });
 
+    it("should have tabIndex -1 on the toggle button to skip it in tab navigation", () => {
+        render(<PasswordField label="Password" id="password" />);
+
+        expect(
+            screen.getByRole("button", { name: "toggle password visibility" })
+        ).toHaveAttribute("tabindex", "-1");
+    });
+
     it("should call preventDefault on mouse down of the toggle button to preserve input focus", async () => {
         render(<PasswordField label="Password" id="password" />);
         const toggleButton = screen.getByRole("button", {


### PR DESCRIPTION
Fixes #250

## Changes

- **`PasswordField.tsx`**: Added `tabIndex={-1}` to the visibility toggle `IconButton`.
- **`DesignSystemPage.tsx`**: Added `tabIndex={-1}` to the two non-disabled decorative end-adornment `IconButton`s. The already-disabled one is unchanged.
- **`PasswordField.test.tsx`**: Added assertion that the toggle button has `tabindex="-1"`.

## Notes

No other Visibility/VisibilityOff icon buttons in the codebase require changes.