### PR TITLE
feat: obfuscate resource IDs in API responses

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/CreateCollectionTests.fs
@@ -3,10 +3,12 @@ namespace Wordfolio.Api.Tests.Collections
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Collections.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -23,6 +25,8 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
@@ -47,6 +51,11 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdCollectionId = result.Id
 
+            let createdCollectionDatabaseId =
+                createdCollectionId
+                |> encoder.Decode
+                |> Option.get
+
             let expectedResult: CollectionResponse =
                 { Id = createdCollectionId
                   Name = "My Collection"
@@ -59,7 +68,7 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! databaseState = Seeder.getAllCollectionsAsync fixture.WordfolioSeeder
 
             let expectedDatabaseState: Wordfolio.Collection list =
-                [ { Id = createdCollectionId
+                [ { Id = createdCollectionDatabaseId
                     UserId = 100
                     Name = "My Collection"
                     Description = Some "A test collection"
@@ -77,6 +86,8 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             use client = factory.CreateClient()
 
@@ -100,6 +111,8 @@ type CreateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/DeleteCollectionTests.fs
@@ -3,9 +3,11 @@ namespace Wordfolio.Api.Tests.Collections
 open System
 open System.Net
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -22,6 +24,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
@@ -48,7 +52,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Collections.collectionById collection.Id)
+            let! response = client.DeleteAsync(Urls.Collections.collectionById(encoder.Encode collection.Id))
             let! body = response.Content.ReadAsStringAsync()
 
             Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
@@ -79,6 +83,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(112, "user@example.com", "P@ssw0rd!")
 
@@ -119,7 +125,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Collections.collectionById collection.Id)
+            let! response = client.DeleteAsync(Urls.Collections.collectionById(encoder.Encode collection.Id))
             let! body = response.Content.ReadAsStringAsync()
 
             Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
@@ -186,6 +192,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -195,7 +203,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Collections.collectionById 999999)
+            let! response = client.DeleteAsync(Urls.Collections.collectionById(encoder.Encode 999999))
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -207,6 +215,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
@@ -230,7 +240,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use client = factory.CreateClient()
 
-            let! response = client.DeleteAsync(Urls.Collections.collectionById collection.Id)
+            let! response = client.DeleteAsync(Urls.Collections.collectionById(encoder.Encode collection.Id))
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
 
@@ -256,6 +266,8 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(110, "owner@example.com", "P@ssw0rd!")
 
@@ -291,7 +303,7 @@ type DeleteCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
-            let! response = client.DeleteAsync(Urls.Collections.collectionById ownerCollection.Id)
+            let! response = client.DeleteAsync(Urls.Collections.collectionById(encoder.Encode ownerCollection.Id))
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionByIdTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Collections.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
@@ -47,7 +51,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Collections.collectionById collection.Id)
+            let! response = client.GetAsync(Urls.Collections.collectionById(encoder.Encode collection.Id))
             let! body = response.Content.ReadAsStringAsync()
 
             Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
@@ -55,7 +59,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<CollectionResponse>()
 
             let expected: CollectionResponse =
-                { Id = collection.Id
+                { Id = encoder.Encode collection.Id
                   Name = "Test Collection"
                   Description = Some "Test Description"
                   CreatedAt = collection.CreatedAt
@@ -72,6 +76,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(104, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -81,7 +87,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Collections.collectionById 999999)
+            let! response = client.GetAsync(Urls.Collections.collectionById(encoder.Encode 999999))
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -93,6 +99,8 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(105, "owner@example.com", "P@ssw0rd!")
 
@@ -119,7 +127,7 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
-            let! response = client.GetAsync(Urls.Collections.collectionById ownerCollection.Id)
+            let! response = client.GetAsync(Urls.Collections.collectionById(encoder.Encode ownerCollection.Id))
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode)
         }
@@ -132,9 +140,11 @@ type GetCollectionByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
-            let! response = client.GetAsync(Urls.Collections.collectionById 1)
+            let! response = client.GetAsync(Urls.Collections.collectionById(encoder.Encode 1))
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/GetCollectionsTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Collections.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! firstIdentityUser, firstWordfolioUser = factory.CreateUserAsync(100, "user1@example.com", "P@ssw0rd!")
 
@@ -66,7 +70,7 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
             let! actualCollections = response.Content.ReadFromJsonAsync<CollectionResponse list>()
 
             let expectedCollections: CollectionResponse list =
-                [ { Id = firstUserCollection.Id
+                [ { Id = encoder.Encode firstUserCollection.Id
                     Name = "First User Collection"
                     Description = Some "Owned by first user"
                     CreatedAt = firstUserCollection.CreatedAt
@@ -82,6 +86,8 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
@@ -110,6 +116,8 @@ type GetCollectionsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             use client = factory.CreateClient()
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Collections/UpdateCollectionTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Collections.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(105, "user@example.com", "P@ssw0rd!")
 
@@ -48,7 +52,9 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Name = "Updated Name"
                   Description = Some "Updated Description" }
 
-            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById collection.Id, updateRequest)
+            let! response =
+                client.PutAsJsonAsync(Urls.Collections.collectionById(encoder.Encode collection.Id), updateRequest)
+
             let! body = response.Content.ReadAsStringAsync()
 
             Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
@@ -93,6 +99,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -106,7 +114,7 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Name = "Updated Name"
                   Description = Some "Updated Description" }
 
-            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById 999999, updateRequest)
+            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById(encoder.Encode 999999), updateRequest)
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -118,6 +126,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(106, "user@example.com", "P@ssw0rd!")
 
@@ -139,7 +149,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Name = ""
                   Description = Some "Updated Description" }
 
-            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById collection.Id, updateRequest)
+            let! response =
+                client.PutAsJsonAsync(Urls.Collections.collectionById(encoder.Encode collection.Id), updateRequest)
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode)
 
@@ -165,6 +176,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(107, "owner@example.com", "P@ssw0rd!")
 
@@ -198,7 +211,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Name = "Updated Name"
                   Description = Some "Updated Description" }
 
-            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById ownerCollection.Id, updateRequest)
+            let! response =
+                client.PutAsJsonAsync(Urls.Collections.collectionById(encoder.Encode ownerCollection.Id), updateRequest)
 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode)
 
@@ -242,6 +256,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(109, "user@example.com", "P@ssw0rd!")
 
             let timestamp =
@@ -268,7 +284,8 @@ type UpdateCollectionTests(fixture: WordfolioIdentityTestFixture) =
                 { Name = "Updated Name"
                   Description = Some "Updated Description" }
 
-            let! response = client.PutAsJsonAsync(Urls.Collections.collectionById collection.Id, updateRequest)
+            let! response =
+                client.PutAsJsonAsync(Urls.Collections.collectionById(encoder.Encode collection.Id), updateRequest)
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsHierarchyTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.CollectionsHierarchy.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
@@ -70,33 +74,33 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let actualCollection1 =
                 actual.Collections
-                |> List.find(fun c -> c.Id = collection1.Id)
+                |> List.find(fun c -> c.Id = encoder.Encode collection1.Id)
 
             let actualCollection2 =
                 actual.Collections
-                |> List.find(fun c -> c.Id = collection2.Id)
+                |> List.find(fun c -> c.Id = encoder.Encode collection2.Id)
 
             let expected: CollectionsHierarchyResultResponse =
                 { Collections =
-                    [ { Id = collection1.Id
+                    [ { Id = encoder.Encode collection1.Id
                         Name = "Collection 1"
                         Description = Some "Description 1"
                         CreatedAt = actualCollection1.CreatedAt
                         UpdatedAt = actualCollection1.CreatedAt
                         Vocabularies =
-                          [ { Id = vocabulary1.Id
+                          [ { Id = encoder.Encode vocabulary1.Id
                               Name = "Vocabulary 1"
                               Description = Some "Vocab description"
                               CreatedAt = actualCollection1.Vocabularies[0].CreatedAt
                               UpdatedAt = actualCollection1.Vocabularies[0].CreatedAt
                               EntryCount = 2 }
-                            { Id = vocabulary2.Id
+                            { Id = encoder.Encode vocabulary2.Id
                               Name = "Vocabulary 2"
                               Description = None
                               CreatedAt = actualCollection1.Vocabularies[1].CreatedAt
                               UpdatedAt = actualCollection1.Vocabularies[1].CreatedAt
                               EntryCount = 1 } ] }
-                      { Id = collection2.Id
+                      { Id = encoder.Encode collection2.Id
                         Name = "Collection 2"
                         Description = None
                         CreatedAt = actualCollection2.CreatedAt
@@ -114,6 +118,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(306, "requester@example.com", "P@ssw0rd!")
@@ -188,13 +194,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: CollectionsHierarchyResultResponse =
                 { Collections =
-                    [ { Id = requesterCollection.Id
+                    [ { Id = encoder.Encode requesterCollection.Id
                         Name = "Requester Collection"
                         Description = Some "Requester Description"
                         CreatedAt = actualCollection.CreatedAt
                         UpdatedAt = actualCollection.CreatedAt
                         Vocabularies =
-                          [ { Id = requesterVocabulary.Id
+                          [ { Id = encoder.Encode requesterVocabulary.Id
                               Name = "Requester Vocabulary"
                               Description = Some "Requester Vocab Description"
                               CreatedAt = actualVocabulary.CreatedAt
@@ -212,6 +218,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
@@ -244,7 +252,7 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: CollectionsHierarchyResultResponse =
                 { Collections =
-                    [ { Id = regularCollection.Id
+                    [ { Id = encoder.Encode regularCollection.Id
                         Name = "Regular Collection"
                         Description = None
                         CreatedAt = actualCollection.CreatedAt
@@ -262,6 +270,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
@@ -298,13 +308,13 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: CollectionsHierarchyResultResponse =
                 { Collections =
-                    [ { Id = collection.Id
+                    [ { Id = encoder.Encode collection.Id
                         Name = "Test Collection"
                         Description = None
                         CreatedAt = actualCollection.CreatedAt
                         UpdatedAt = actualCollection.CreatedAt
                         Vocabularies =
-                          [ { Id = regularVocabulary.Id
+                          [ { Id = encoder.Encode regularVocabulary.Id
                               Name = "Regular Vocabulary"
                               Description = None
                               CreatedAt = actualCollection.Vocabularies[0].CreatedAt
@@ -322,6 +332,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(303, "user@example.com", "P@ssw0rd!")
 
@@ -353,6 +365,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
@@ -392,7 +406,7 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
                 { Collections = []
                   DefaultVocabulary =
                     Some
-                        { Id = defaultVocabulary.Id
+                        { Id = encoder.Encode defaultVocabulary.Id
                           Name = "My Words"
                           Description = Some "Default vocab"
                           CreatedAt = defaultVocabulary.CreatedAt
@@ -409,6 +423,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(305, "user@example.com", "P@ssw0rd!")
 
@@ -451,6 +467,8 @@ type GetCollectionsHierarchyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             use client = factory.CreateClient()
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsListTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetCollectionsListTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.CollectionsHierarchy.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(306, "user@example.com", "P@ssw0rd!")
 
@@ -62,19 +66,19 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<CollectionWithVocabularyCountResponse list>()
 
             let expected: CollectionWithVocabularyCountResponse list =
-                [ { Id = collection2.Id
+                [ { Id = encoder.Encode collection2.Id
                     Name = "Travel"
                     Description = Some "Bio terms"
                     CreatedAt = createdAt
                     UpdatedAt = updatedAt2
                     VocabularyCount = 0 }
-                  { Id = collection1.Id
+                  { Id = encoder.Encode collection1.Id
                     Name = "Biology"
                     Description = Some "School words"
                     CreatedAt = createdAt
                     UpdatedAt = updatedAt1
                     VocabularyCount = 0 }
-                  { Id = collection3.Id
+                  { Id = encoder.Encode collection3.Id
                     Name = "Sports"
                     Description = None
                     CreatedAt = createdAt
@@ -91,6 +95,8 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(310, "user@example.com", "P@ssw0rd!")
 
@@ -122,7 +128,7 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<CollectionWithVocabularyCountResponse list>()
 
             let expected: CollectionWithVocabularyCountResponse list =
-                [ { Id = ownedCollection.Id
+                [ { Id = encoder.Encode ownedCollection.Id
                     Name = "Owned"
                     Description = None
                     CreatedAt = createdAt
@@ -139,6 +145,8 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(319, "user@example.com", "P@ssw0rd!")
 
@@ -169,6 +177,8 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(317, "user@example.com", "P@ssw0rd!")
 
@@ -214,7 +224,7 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<CollectionWithVocabularyCountResponse list>()
 
             let expected: CollectionWithVocabularyCountResponse list =
-                [ { Id = collection.Id
+                [ { Id = encoder.Encode collection.Id
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
@@ -231,6 +241,8 @@ type GetCollectionsListTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             use client = factory.CreateClient()
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/CollectionsHierarchy/GetVocabulariesByCollectionTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.CollectionsHierarchy.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(312, "user@example.com", "P@ssw0rd!")
 
@@ -53,7 +57,7 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.CollectionsHierarchy.vocabulariesByCollection collection.Id
+                Urls.CollectionsHierarchy.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.GetAsync(url)
 
@@ -64,7 +68,7 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<VocabularyWithEntryCountResponse list>()
 
             let expected: VocabularyWithEntryCountResponse list =
-                [ { Id = regularVocabulary.Id
+                [ { Id = encoder.Encode regularVocabulary.Id
                     Name = "Regular"
                     Description = None
                     CreatedAt = createdAt
@@ -81,6 +85,8 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(313, "user@example.com", "P@ssw0rd!")
 
@@ -111,7 +117,7 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.CollectionsHierarchy.vocabulariesByCollection otherCollection.Id
+                Urls.CollectionsHierarchy.vocabulariesByCollection(encoder.Encode otherCollection.Id)
 
             let! response = client.GetAsync(url)
 
@@ -131,6 +137,8 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(318, "user@example.com", "P@ssw0rd!")
 
@@ -156,7 +164,7 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.CollectionsHierarchy.vocabulariesByCollection collection.Id
+                Urls.CollectionsHierarchy.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.GetAsync(url)
 
@@ -177,10 +185,12 @@ type GetVocabulariesByCollectionTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let url =
-                Urls.CollectionsHierarchy.vocabulariesByCollection 1
+                Urls.CollectionsHierarchy.vocabulariesByCollection(encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/CreateDraftTests.fs
@@ -4,11 +4,13 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Drafts.Types
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -25,6 +27,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(400, "user@example.com", "P@ssw0rd!")
 
@@ -64,7 +68,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = vocabularies.[0].Id
+                  VocabularyId = encoder.Encode vocabularies.[0].Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt
@@ -101,6 +105,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(401, "user@example.com", "P@ssw0rd!")
 
@@ -148,7 +154,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = defaultVocabulary.Id
+                  VocabularyId = encoder.Encode defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt
@@ -187,6 +193,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(600, "user@example.com", "P@ssw0rd!")
 
@@ -249,7 +257,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = vocabularies.[0].Id
+                  VocabularyId = encoder.Encode vocabularies.[0].Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt
@@ -312,6 +320,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let request: CreateDraftRequest =
@@ -353,6 +363,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(601, "user@example.com", "P@ssw0rd!")
 
@@ -403,6 +415,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(602, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -448,6 +462,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(603, "user@example.com", "P@ssw0rd!")
 
@@ -510,6 +526,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(604, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -555,6 +573,8 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(605, "user@example.com", "P@ssw0rd!")
 
@@ -606,7 +626,7 @@ type CreateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = defaultVocabulary.Id
+                  VocabularyId = encoder.Encode defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/DeleteDraftTests.fs
@@ -3,9 +3,11 @@ namespace Wordfolio.Api.Tests.Drafts
 open System
 open System.Net
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -22,6 +24,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(706, "user@example.com", "P@ssw0rd!")
 
@@ -50,7 +54,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.DeleteAsync(url)
 
@@ -84,6 +89,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(707, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -108,7 +115,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use client = factory.CreateClient()
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.DeleteAsync(url)
 
@@ -133,6 +141,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(708, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -142,7 +152,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let url = Urls.Drafts.draftById 999999
+            let url =
+                Urls.Drafts.draftById(encoder.Encode 999999)
 
             let! response = client.DeleteAsync(url)
 
@@ -156,6 +167,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser1 = factory.CreateUserAsync(715, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(716, "user2@example.com", "P@ssw0rd!")
@@ -191,7 +204,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser2)
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.DeleteAsync(url)
 
@@ -232,6 +246,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
@@ -282,7 +298,8 @@ type DeleteDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.DeleteAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftByIdTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(700, "user@example.com", "P@ssw0rd!")
 
@@ -74,7 +78,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -108,8 +113,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Examples = [ expectedTranslationExample ] }
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = entry.UpdatedAt
@@ -127,6 +132,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(701, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -136,7 +143,8 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let url = Urls.Drafts.draftById 999999
+            let url =
+                Urls.Drafts.draftById(encoder.Encode 999999)
 
             let! response = client.GetAsync(url)
 
@@ -151,9 +159,12 @@ type GetDraftByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
-            let url = Urls.Drafts.draftById 1
+            let url =
+                Urls.Drafts.draftById(encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftsTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/GetDraftsTests.fs
@@ -4,11 +4,13 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Drafts.Types
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -26,6 +28,8 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let! response = client.GetAsync(Urls.Drafts.allDrafts())
@@ -40,6 +44,8 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
@@ -74,6 +80,8 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
             let createdAt =
@@ -103,7 +111,7 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: DraftsVocabularyDataResponse =
                 { Vocabulary =
-                    { Id = defaultVocab.Id
+                    { Id = encoder.Encode defaultVocab.Id
                       Name = "Drafts"
                       Description = Some "My drafts"
                       CreatedAt = actual.Vocabulary.CreatedAt
@@ -120,6 +128,8 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(100, "user@example.com", "P@ssw0rd!")
 
@@ -177,28 +187,28 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: DraftsVocabularyDataResponse =
                 { Vocabulary =
-                    { Id = defaultVocab.Id
+                    { Id = encoder.Encode defaultVocab.Id
                       Name = "Drafts"
                       Description = None
                       CreatedAt = actual.Vocabulary.CreatedAt
                       UpdatedAt = actual.Vocabulary.CreatedAt }
                   Entries =
-                    [ { Id = entry.Id
-                        VocabularyId = defaultVocab.Id
+                    [ { Id = encoder.Encode entry.Id
+                        VocabularyId = encoder.Encode defaultVocab.Id
                         EntryText = "ephemeral"
                         CreatedAt = actual.Entries.[0].CreatedAt
                         UpdatedAt = actual.Entries.[0].CreatedAt
                         Definitions =
-                          [ { Id = definition.Id
+                          [ { Id = encoder.Encode definition.Id
                               DefinitionText = "lasting for a short time"
                               Source = DefinitionSource.Api
                               DisplayOrder = 1
                               Examples =
-                                [ { Id = example.Id
+                                [ { Id = encoder.Encode example.Id
                                     ExampleText = "ephemeral pleasures"
                                     Source = ExampleSource.Custom } ] } ]
                         Translations =
-                          [ { Id = translation.Id
+                          [ { Id = encoder.Encode translation.Id
                               TranslationText = "эфемерный"
                               Source = TranslationSource.Manual
                               DisplayOrder = 1
@@ -214,6 +224,8 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(100, "user1@example.com", "P@ssw0rd!")
 
@@ -255,14 +267,14 @@ type GetDraftsTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: DraftsVocabularyDataResponse =
                 { Vocabulary =
-                    { Id = vocab1.Id
+                    { Id = encoder.Encode vocab1.Id
                       Name = "Drafts1"
                       Description = None
                       CreatedAt = actual.Vocabulary.CreatedAt
                       UpdatedAt = actual.Vocabulary.CreatedAt }
                   Entries =
-                    [ { Id = entry1.Id
-                        VocabularyId = vocab1.Id
+                    [ { Id = encoder.Encode entry1.Id
+                        VocabularyId = encoder.Encode vocab1.Id
                         EntryText = "myword"
                         CreatedAt = actual.Entries.[0].CreatedAt
                         UpdatedAt = actual.Entries.[0].CreatedAt

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/MoveDraftTests.fs
@@ -4,11 +4,13 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Drafts.Types
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -25,6 +27,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(709, "user@example.com", "P@ssw0rd!")
 
@@ -57,9 +61,10 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveDraftRequest =
-                { VocabularyId = targetVocabulary.Id }
+                { VocabularyId = encoder.Encode targetVocabulary.Id }
 
-            let url = Urls.Drafts.moveDraftById entry.Id
+            let url =
+                Urls.Drafts.moveDraftById(encoder.Encode entry.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -72,8 +77,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = targetVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode targetVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -124,6 +129,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(717, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -152,9 +159,9 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use client = factory.CreateClient()
 
             let request: MoveDraftRequest =
-                { VocabularyId = targetVocabulary.Id }
+                { VocabularyId = encoder.Encode targetVocabulary.Id }
 
-            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById entry.Id, request)
+            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById(encoder.Encode entry.Id), request)
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
 
@@ -177,6 +184,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(710, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -187,9 +196,9 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveDraftRequest =
-                { VocabularyId = 999 }
+                { VocabularyId = encoder.Encode 999 }
 
-            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById 999999, request)
+            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById(encoder.Encode 999999), request)
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -201,6 +210,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(711, "user@example.com", "P@ssw0rd!")
 
@@ -227,9 +238,9 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveDraftRequest =
-                { VocabularyId = 999999 }
+                { VocabularyId = encoder.Encode 999999 }
 
-            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById entry.Id, request)
+            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById(encoder.Encode entry.Id), request)
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -241,6 +252,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(718, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(719, "user2@example.com", "P@ssw0rd!")
@@ -283,9 +296,9 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser1)
 
             let request: MoveDraftRequest =
-                { VocabularyId = foreignTargetVocabulary.Id }
+                { VocabularyId = encoder.Encode foreignTargetVocabulary.Id }
 
-            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById entry.Id, request)
+            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById(encoder.Encode entry.Id), request)
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
 
@@ -325,6 +338,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(720, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -356,9 +371,9 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveDraftRequest =
-                { VocabularyId = defaultVocabulary.Id }
+                { VocabularyId = encoder.Encode defaultVocabulary.Id }
 
-            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById entry.Id, request)
+            let! response = client.PostAsJsonAsync(Urls.Drafts.moveDraftById(encoder.Encode entry.Id), request)
             let! body = response.Content.ReadAsStringAsync()
 
             Assert.True(response.IsSuccessStatusCode, $"Status: {response.StatusCode}. Body: {body}")
@@ -369,8 +384,8 @@ type MoveDraftTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = defaultVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Drafts/UpdateDraftTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(702, "user@example.com", "P@ssw0rd!")
 
@@ -110,7 +114,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                           [ { ExampleText = "Hola ahi!"
                               Source = ExampleSource.Custom } ] } ] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -147,8 +152,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello updated"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -240,6 +245,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(715, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -295,7 +302,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -319,6 +327,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(703, "user@example.com", "P@ssw0rd!")
 
@@ -357,7 +367,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -381,6 +392,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(704, "user@example.com", "P@ssw0rd!")
 
@@ -416,7 +429,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                   Definitions = []
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -441,6 +455,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(705, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -458,7 +474,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById 999999
+            let url =
+                Urls.Drafts.draftById(encoder.Encode 999999)
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -472,6 +489,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(712, "user@example.com", "P@ssw0rd!")
 
@@ -505,7 +524,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -525,8 +545,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -569,6 +589,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser1 = factory.CreateUserAsync(713, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(714, "user2@example.com", "P@ssw0rd!")
@@ -624,7 +646,8 @@ type UpdateDraftTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let url = Urls.Drafts.draftById entry.Id
+            let url =
+                Urls.Drafts.draftById(encoder.Encode entry.Id)
 
             let! response = client.PutAsJsonAsync(url, request)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/CreateEntryTests.fs
@@ -4,11 +4,13 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
 open Wordfolio.Api.Api.Entries.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -25,6 +27,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(300, "user@example.com", "P@ssw0rd!")
 
@@ -63,7 +67,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -99,7 +103,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = vocabulary.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt
@@ -162,6 +166,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(320, "auth-required@example.com", "P@ssw0rd!")
 
             let now =
@@ -192,7 +198,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -218,6 +224,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(301, "user@example.com", "P@ssw0rd!")
 
@@ -249,7 +257,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -275,6 +283,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(321, "requester@example.com", "P@ssw0rd!")
@@ -314,7 +324,10 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Entries.entriesByVocabulary(ownerCollection.Id, ownerVocabulary.Id),
+                    Urls.Entries.entriesByVocabulary(
+                        encoder.Encode ownerCollection.Id,
+                        encoder.Encode ownerVocabulary.Id
+                    ),
                     request
                 )
 
@@ -347,6 +360,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(302, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -374,7 +389,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -388,6 +403,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(303, "user@example.com", "P@ssw0rd!")
 
@@ -431,7 +448,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -445,6 +462,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(304, "user@example.com", "P@ssw0rd!")
 
@@ -480,7 +499,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -494,6 +513,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(319, "user@example.com", "P@ssw0rd!")
 
@@ -529,7 +550,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = Some true }
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -548,7 +569,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse =
                 { Id = actual.Id
-                  VocabularyId = vocabulary.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = actual.CreatedAt
                   UpdatedAt = actual.CreatedAt
@@ -581,6 +602,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(305, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -600,7 +623,7 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let url =
-                Urls.Entries.entriesByVocabulary(1, 999999)
+                Urls.Entries.entriesByVocabulary(encoder.Encode 1, encoder.Encode 999999)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -614,6 +637,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
@@ -644,7 +669,11 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = []
                   AllowDuplicate = None }
 
-            let! response = client.PostAsJsonAsync(Urls.Entries.entriesByVocabulary(999999, vocabulary.Id), request)
+            let! response =
+                client.PostAsJsonAsync(
+                    Urls.Entries.entriesByVocabulary(encoder.Encode 999999, encoder.Encode vocabulary.Id),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -656,6 +685,8 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(517, "user@example.com", "P@ssw0rd!")
 
@@ -693,7 +724,10 @@ type CreateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   AllowDuplicate = None }
 
             let! response =
-                client.PostAsJsonAsync(Urls.Entries.entriesByVocabulary(collectionA.Id, vocabularyB.Id), request)
+                client.PostAsJsonAsync(
+                    Urls.Entries.entriesByVocabulary(encoder.Encode collectionA.Id, encoder.Encode vocabularyB.Id),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/DeleteEntryTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(402, "user@example.com", "P@ssw0rd!")
 
@@ -53,7 +57,11 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.DeleteAsync(url)
 
@@ -87,6 +95,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(403, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -112,7 +122,11 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use client = factory.CreateClient()
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.DeleteAsync(url)
 
@@ -137,6 +151,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(404, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -147,7 +163,7 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entryById(1, 1, 999999)
+                Urls.Entries.entryById(encoder.Encode 1, encoder.Encode 1, encoder.Encode 999999)
 
             let! response = client.DeleteAsync(url)
 
@@ -161,6 +177,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser1 = factory.CreateUserAsync(405, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(406, "user2@example.com", "P@ssw0rd!")
@@ -197,7 +215,11 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser2)
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.DeleteAsync(url)
 
@@ -238,6 +260,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(407, "user@example.com", "P@ssw0rd!")
 
@@ -289,7 +313,11 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.DeleteAsync(url)
 
@@ -316,6 +344,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(510, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -340,7 +370,10 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Entries.entryById(999999, vocabulary.Id, entry.Id))
+            let! response =
+                client.DeleteAsync(
+                    Urls.Entries.entryById(encoder.Encode 999999, encoder.Encode vocabulary.Id, encoder.Encode entry.Id)
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -352,6 +385,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(514, "user@example.com", "P@ssw0rd!")
 
@@ -380,7 +415,14 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Entries.entryById(collection.Id, vocabularyB.Id, entry.Id))
+            let! response =
+                client.DeleteAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode vocabularyB.Id,
+                        encoder.Encode entry.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -392,6 +434,8 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(521, "user@example.com", "P@ssw0rd!")
 
@@ -420,7 +464,14 @@ type DeleteEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.DeleteAsync(Urls.Entries.entryById(collectionA.Id, vocabulary.Id, entry.Id))
+            let! response =
+                client.DeleteAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collectionA.Id,
+                        encoder.Encode vocabulary.Id,
+                        encoder.Encode entry.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntriesByVocabularyTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(308, "user@example.com", "P@ssw0rd!")
 
@@ -53,7 +57,7 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -69,14 +73,14 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let expected: EntryResponse list =
                 [ { Id = actual.[0].Id
-                    VocabularyId = vocabulary.Id
+                    VocabularyId = encoder.Encode vocabulary.Id
                     EntryText = "hello"
                     CreatedAt = actual.[0].CreatedAt
                     UpdatedAt = actual.[0].CreatedAt
                     Definitions = []
                     Translations = [] }
                   { Id = actual.[1].Id
-                    VocabularyId = vocabulary.Id
+                    VocabularyId = encoder.Encode vocabulary.Id
                     EntryText = "world"
                     CreatedAt = actual.[1].CreatedAt
                     UpdatedAt = actual.[1].CreatedAt
@@ -93,6 +97,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(309, "user@example.com", "P@ssw0rd!")
 
@@ -115,7 +121,7 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entriesByVocabulary(collection.Id, vocabulary.Id)
+                Urls.Entries.entriesByVocabulary(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -136,10 +142,12 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let url =
-                Urls.Entries.entriesByVocabulary(1, 1)
+                Urls.Entries.entriesByVocabulary(encoder.Encode 1, encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 
@@ -154,6 +162,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(310, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -164,7 +174,7 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entriesByVocabulary(1, 999999)
+                Urls.Entries.entriesByVocabulary(encoder.Encode 1, encoder.Encode 999999)
 
             let! response = client.GetAsync(url)
 
@@ -178,6 +188,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! requesterIdentityUser, requesterWordfolioUser =
                 factory.CreateUserAsync(311, "requester@example.com", "P@ssw0rd!")
@@ -212,7 +224,13 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entriesByVocabulary(otherCollection.Id, otherVocabulary.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entriesByVocabulary(
+                        encoder.Encode otherCollection.Id,
+                        encoder.Encode otherVocabulary.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -224,6 +242,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
@@ -245,7 +265,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entriesByVocabulary(999999, vocabulary.Id))
+            let! response =
+                client.GetAsync(Urls.Entries.entriesByVocabulary(encoder.Encode 999999, encoder.Encode vocabulary.Id))
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -257,6 +278,8 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(516, "user@example.com", "P@ssw0rd!")
 
@@ -284,7 +307,10 @@ type GetEntriesByVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entriesByVocabulary(collectionA.Id, vocabularyB.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entriesByVocabulary(encoder.Encode collectionA.Id, encoder.Encode vocabularyB.Id)
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/GetEntryByIdTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(306, "user@example.com", "P@ssw0rd!")
 
@@ -75,7 +79,11 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -109,8 +117,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
                   Examples = [ expectedTranslationExample ] }
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = entry.UpdatedAt
@@ -128,6 +136,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(307, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -138,7 +148,7 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Entries.entryById(1, 1, 999999)
+                Urls.Entries.entryById(encoder.Encode 1, encoder.Encode 1, encoder.Encode 999999)
 
             let! response = client.GetAsync(url)
 
@@ -152,6 +162,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(520, "owner@example.com", "P@ssw0rd!")
 
@@ -181,7 +193,13 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
             let! response =
-                client.GetAsync(Urls.Entries.entryById(ownerCollection.Id, ownerVocabulary.Id, ownerEntry.Id))
+                client.GetAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode ownerCollection.Id,
+                        encoder.Encode ownerVocabulary.Id,
+                        encoder.Encode ownerEntry.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -194,9 +212,12 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
-            let url = Urls.Entries.entryById(1, 1, 1)
+            let url =
+                Urls.Entries.entryById(encoder.Encode 1, encoder.Encode 1, encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 
@@ -210,6 +231,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
@@ -235,7 +258,10 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entryById(999999, vocabulary.Id, entry.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entryById(encoder.Encode 999999, encoder.Encode vocabulary.Id, encoder.Encode entry.Id)
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -247,6 +273,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(512, "user@example.com", "P@ssw0rd!")
 
@@ -275,7 +303,14 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entryById(collection.Id, vocabularyB.Id, entry.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode vocabularyB.Id,
+                        encoder.Encode entry.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -287,6 +322,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(518, "user@example.com", "P@ssw0rd!")
 
@@ -312,7 +349,10 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entryById(collection.Id, 999999, entry.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entryById(encoder.Encode collection.Id, encoder.Encode 999999, encoder.Encode entry.Id)
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -324,6 +364,8 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(519, "user@example.com", "P@ssw0rd!")
 
@@ -352,7 +394,14 @@ type GetEntryByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
-            let! response = client.GetAsync(Urls.Entries.entryById(collectionA.Id, vocabulary.Id, entry.Id))
+            let! response =
+                client.GetAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collectionA.Id,
+                        encoder.Encode vocabulary.Id,
+                        encoder.Encode entry.Id
+                    )
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/MoveEntryTests.fs
@@ -6,11 +6,13 @@ open System.Net.Http
 open System.Net.Http.Json
 open System.Text
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Entries.Types
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -27,6 +29,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(500, "user@example.com", "P@ssw0rd!")
 
@@ -59,10 +63,14 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some targetVocabulary.Id }
+                { VocabularyId = Some(encoder.Encode targetVocabulary.Id) }
 
             let url =
-                Urls.Entries.moveEntryById(collection.Id, sourceVocabulary.Id, entry.Id)
+                Urls.Entries.moveEntryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode sourceVocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -75,8 +83,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = targetVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode targetVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -127,6 +135,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(526, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -155,11 +165,15 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use client = factory.CreateClient()
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some targetVocabulary.Id }
+                { VocabularyId = Some(encoder.Encode targetVocabulary.Id) }
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Entries.moveEntryById(collection.Id, sourceVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode sourceVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     request
                 )
 
@@ -184,6 +198,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(501, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -194,9 +210,13 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some 999 }
+                { VocabularyId = Some(encoder.Encode 999) }
 
-            let! response = client.PostAsJsonAsync(Urls.Entries.moveEntryById(1, 1, 999999), request)
+            let! response =
+                client.PostAsJsonAsync(
+                    Urls.Entries.moveEntryById(encoder.Encode 1, encoder.Encode 1, encoder.Encode 999999),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -208,6 +228,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(502, "user@example.com", "P@ssw0rd!")
 
@@ -234,11 +256,15 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some 999999 }
+                { VocabularyId = Some(encoder.Encode 999999) }
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Entries.moveEntryById(collection.Id, sourceVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode sourceVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     request
                 )
 
@@ -252,6 +278,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(503, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(504, "user2@example.com", "P@ssw0rd!")
@@ -294,11 +322,15 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser1)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some foreignTargetVocabulary.Id }
+                { VocabularyId = Some(encoder.Encode foreignTargetVocabulary.Id) }
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Entries.moveEntryById(collection1.Id, sourceVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode collection1.Id,
+                        encoder.Encode sourceVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     request
                 )
 
@@ -340,6 +372,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(505, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -371,11 +405,15 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some defaultVocabulary.Id }
+                { VocabularyId = Some(encoder.Encode defaultVocabulary.Id) }
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Entries.moveEntryById(regularCollection.Id, regularVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode regularCollection.Id,
+                        encoder.Encode regularVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     request
                 )
 
@@ -389,8 +427,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = defaultVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -475,6 +513,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(506, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -507,7 +547,11 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! response =
                 client.PostAsync(
-                    Urls.Entries.moveEntryById(regularCollection.Id, regularVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode regularCollection.Id,
+                        encoder.Encode regularVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     new StringContent("{}", Encoding.UTF8, "application/json")
                 )
 
@@ -521,8 +565,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = defaultVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode defaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -620,6 +664,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(507, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -646,7 +692,11 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! response =
                 client.PostAsync(
-                    Urls.Entries.moveEntryById(regularCollection.Id, regularVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode regularCollection.Id,
+                        encoder.Encode regularVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     new StringContent("{}", Encoding.UTF8, "application/json")
                 )
 
@@ -691,8 +741,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expectedResponse: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = createdDefaultVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode createdDefaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -724,6 +774,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(508, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -753,7 +805,11 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             let! response =
                 client.PostAsync(
-                    Urls.Entries.moveEntryById(regularCollection.Id, regularVocabulary.Id, entry.Id),
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode regularCollection.Id,
+                        encoder.Encode regularVocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
                     new StringContent("{}", Encoding.UTF8, "application/json")
                 )
 
@@ -818,8 +874,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expectedResponse: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = createdDefaultVocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode createdDefaultVocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -849,6 +905,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(511, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -874,9 +932,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some vocabulary.Id }
+                { VocabularyId = Some(encoder.Encode vocabulary.Id) }
 
-            let! response = client.PostAsJsonAsync(Urls.Entries.moveEntryById(999999, vocabulary.Id, entry.Id), request)
+            let! response =
+                client.PostAsJsonAsync(
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode 999999,
+                        encoder.Encode vocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -888,6 +954,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(515, "user@example.com", "P@ssw0rd!")
 
@@ -917,10 +985,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some vocabularyA.Id }
+                { VocabularyId = Some(encoder.Encode vocabularyA.Id) }
 
             let! response =
-                client.PostAsJsonAsync(Urls.Entries.moveEntryById(collection.Id, vocabularyB.Id, entry.Id), request)
+                client.PostAsJsonAsync(
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode vocabularyB.Id,
+                        encoder.Encode entry.Id
+                    ),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -932,6 +1007,8 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(522, "user@example.com", "P@ssw0rd!")
 
@@ -961,10 +1038,17 @@ type MoveEntryTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveEntryRequest =
-                { VocabularyId = Some vocabulary.Id }
+                { VocabularyId = Some(encoder.Encode vocabulary.Id) }
 
             let! response =
-                client.PostAsJsonAsync(Urls.Entries.moveEntryById(collectionA.Id, vocabulary.Id, entry.Id), request)
+                client.PostAsJsonAsync(
+                    Urls.Entries.moveEntryById(
+                        encoder.Encode collectionA.Id,
+                        encoder.Encode vocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Entries/UpdateEntryTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(311, "user@example.com", "P@ssw0rd!")
 
@@ -98,7 +102,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                               Source = ExampleSource.Custom } ] } ] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -135,8 +143,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello updated"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -257,6 +265,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! _, wordfolioUser = factory.CreateUserAsync(323, "auth@example.com", "P@ssw0rd!")
 
             let now =
@@ -306,7 +316,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -354,6 +368,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(312, "user@example.com", "P@ssw0rd!")
 
@@ -404,7 +420,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -453,6 +473,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(313, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -491,7 +513,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -532,6 +558,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(314, "user@example.com", "P@ssw0rd!")
 
             do!
@@ -550,7 +578,7 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(1, 1, 999999)
+                Urls.Entries.entryById(encoder.Encode 1, encoder.Encode 1, encoder.Encode 999999)
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -564,6 +592,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(316, "user@example.com", "P@ssw0rd!")
 
@@ -598,7 +628,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -618,8 +652,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             Assert.True(actual.UpdatedAt >= entry.CreatedAt)
 
             let expected: EntryResponse =
-                { Id = entry.Id
-                  VocabularyId = vocabulary.Id
+                { Id = encoder.Encode entry.Id
+                  VocabularyId = encoder.Encode vocabulary.Id
                   EntryText = "hello"
                   CreatedAt = entry.CreatedAt
                   UpdatedAt = actual.UpdatedAt
@@ -662,6 +696,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(317, "user1@example.com", "P@ssw0rd!")
             let! identityUser2, wordfolioUser2 = factory.CreateUserAsync(318, "user2@example.com", "P@ssw0rd!")
@@ -736,7 +772,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let url =
-                Urls.Entries.entryById(collection.Id, vocabulary.Id, entry.Id)
+                Urls.Entries.entryById(
+                    encoder.Encode collection.Id,
+                    encoder.Encode vocabulary.Id,
+                    encoder.Encode entry.Id
+                )
 
             let! response = client.PutAsJsonAsync(url, request)
 
@@ -843,6 +883,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(509, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -875,7 +917,11 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                         Examples = [] } ]
                   Translations = [] }
 
-            let! response = client.PutAsJsonAsync(Urls.Entries.entryById(999999, vocabulary.Id, entry.Id), request)
+            let! response =
+                client.PutAsJsonAsync(
+                    Urls.Entries.entryById(encoder.Encode 999999, encoder.Encode vocabulary.Id, encoder.Encode entry.Id),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -887,6 +933,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(513, "user@example.com", "P@ssw0rd!")
 
@@ -924,7 +972,14 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let! response =
-                client.PutAsJsonAsync(Urls.Entries.entryById(collection.Id, vocabularyB.Id, entry.Id), request)
+                client.PutAsJsonAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collection.Id,
+                        encoder.Encode vocabularyB.Id,
+                        encoder.Encode entry.Id
+                    ),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -936,6 +991,8 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(520, "user@example.com", "P@ssw0rd!")
 
@@ -973,7 +1030,14 @@ type UpdateEntryTests(fixture: WordfolioIdentityTestFixture) =
                   Translations = [] }
 
             let! response =
-                client.PutAsJsonAsync(Urls.Entries.entryById(collectionA.Id, vocabulary.Id, entry.Id), request)
+                client.PutAsJsonAsync(
+                    Urls.Entries.entryById(
+                        encoder.Encode collectionA.Id,
+                        encoder.Encode vocabulary.Id,
+                        encoder.Encode entry.Id
+                    ),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/CreateVocabularyTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Vocabularies.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(200, "user@example.com", "P@ssw0rd!")
 
@@ -46,7 +50,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "A test vocabulary" }
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection collection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -58,9 +62,14 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             let createdVocabularyId = result.Id
 
+            let createdVocabularyDatabaseId =
+                createdVocabularyId
+                |> encoder.Decode
+                |> Option.get
+
             let expectedResult: VocabularyResponse =
                 { Id = createdVocabularyId
-                  CollectionId = collection.Id
+                  CollectionId = encoder.Encode collection.Id
                   Name = "Test Vocabulary"
                   Description = Some "A test vocabulary"
                   CreatedAt = result.CreatedAt
@@ -71,7 +80,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! databaseState = Seeder.getAllVocabulariesAsync fixture.WordfolioSeeder
 
             let expectedDatabaseState: Wordfolio.Vocabulary list =
-                [ { Id = createdVocabularyId
+                [ { Id = createdVocabularyDatabaseId
                     CollectionId = collection.Id
                     Name = "Test Vocabulary"
                     Description = Some "A test vocabulary"
@@ -89,6 +98,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
@@ -111,7 +122,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "A test vocabulary" }
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection collection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -129,6 +140,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(206, "owner@example.com", "P@ssw0rd!")
 
@@ -154,7 +167,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Should not be created" }
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection ownerCollection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode ownerCollection.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 
@@ -172,6 +185,8 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(201, "user@example.com", "P@ssw0rd!")
 
@@ -194,7 +209,7 @@ type CreateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "A test vocabulary" }
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection collection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/DeleteVocabularyTests.fs
@@ -3,9 +3,11 @@ namespace Wordfolio.Api.Tests.Vocabularies
 open System
 open System.Net
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -22,6 +24,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
@@ -44,7 +48,7 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.DeleteAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -67,6 +71,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(209, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -84,7 +90,7 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, 999999)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode 999999)
 
             let! response = client.DeleteAsync(url)
 
@@ -98,6 +104,8 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(218, "user@example.com", "P@ssw0rd!")
 
@@ -126,7 +134,7 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collectionA.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collectionA.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.DeleteAsync(url)
 
@@ -157,10 +165,12 @@ type DeleteVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let url =
-                Urls.Vocabularies.vocabularyById(1, 1)
+                Urls.Vocabularies.vocabularyById(encoder.Encode 1, encoder.Encode 1)
 
             let! response = client.DeleteAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabulariesTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Vocabularies.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(208, "user@example.com", "P@ssw0rd!")
 
@@ -49,7 +53,7 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection collection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -64,14 +68,14 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
                 result |> Array.sortBy _.Id
 
             let expected: VocabularyResponse[] =
-                [| { Id = firstVocabulary.Id
-                     CollectionId = collection.Id
+                [| { Id = encoder.Encode firstVocabulary.Id
+                     CollectionId = encoder.Encode collection.Id
                      Name = "Animals"
                      Description = Some "Animal words"
                      CreatedAt = sortedResult[0].CreatedAt
                      UpdatedAt = sortedResult[0].CreatedAt }
-                   { Id = secondVocabulary.Id
-                     CollectionId = collection.Id
+                   { Id = encoder.Encode secondVocabulary.Id
+                     CollectionId = encoder.Encode collection.Id
                      Name = "Travel"
                      Description = None
                      CreatedAt = sortedResult[1].CreatedAt
@@ -88,6 +92,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(202, "user@example.com", "P@ssw0rd!")
 
@@ -106,7 +112,7 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection collection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode collection.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -127,10 +133,12 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection 1
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 
@@ -144,6 +152,8 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(209, "owner@example.com", "P@ssw0rd!")
 
@@ -175,7 +185,7 @@ type GetVocabulariesTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
             let url =
-                Urls.Vocabularies.vocabulariesByCollection ownerCollection.Id
+                Urls.Vocabularies.vocabulariesByCollection(encoder.Encode ownerCollection.Id)
 
             let! response = client.GetAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/GetVocabularyByIdTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Vocabularies.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(203, "user@example.com", "P@ssw0rd!")
 
@@ -46,7 +50,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.GetAsync(url)
             let! body = response.Content.ReadAsStringAsync()
@@ -56,8 +60,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<VocabularyDetailResponse>()
 
             let expected: VocabularyDetailResponse =
-                { Id = vocabulary.Id
-                  CollectionId = collection.Id
+                { Id = encoder.Encode vocabulary.Id
+                  CollectionId = encoder.Encode collection.Id
                   CollectionName = "Test Collection"
                   Name = "Test Vocabulary"
                   Description = Some "Test Description"
@@ -74,6 +78,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(204, "user@example.com", "P@ssw0rd!")
 
@@ -92,7 +98,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, 999999)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode 999999)
 
             let! response = client.GetAsync(url)
 
@@ -106,6 +112,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(216, "user@example.com", "P@ssw0rd!")
 
@@ -131,7 +139,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(collectionA.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collectionA.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.GetAsync(url)
 
@@ -145,6 +153,8 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(211, "owner@example.com", "P@ssw0rd!")
 
@@ -182,7 +192,7 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(requesterIdentityUser)
 
             let url =
-                Urls.Vocabularies.vocabularyById(ownerCollection.Id, ownerVocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode ownerCollection.Id, encoder.Encode ownerVocabulary.Id)
 
             let! response = client.GetAsync(url)
 
@@ -197,10 +207,12 @@ type GetVocabularyByIdTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let url =
-                Urls.Vocabularies.vocabularyById(1, 1)
+                Urls.Vocabularies.vocabularyById(encoder.Encode 1, encoder.Encode 1)
 
             let! response = client.GetAsync(url)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/MoveVocabularyTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Vocabularies.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(600, "user@example.com", "P@ssw0rd!")
 
@@ -55,10 +59,10 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveVocabularyRequest =
-                { CollectionId = targetCollection.Id }
+                { CollectionId = encoder.Encode targetCollection.Id }
 
             let url =
-                Urls.Vocabularies.moveVocabularyById(sourceCollection.Id, vocabulary.Id)
+                Urls.Vocabularies.moveVocabularyById(encoder.Encode sourceCollection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PostAsJsonAsync(url, request)
             let! body = response.Content.ReadAsStringAsync()
@@ -69,8 +73,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! actual = response.Content.ReadFromJsonAsync<VocabularyResponse>()
 
             let expected: VocabularyResponse =
-                { Id = vocabulary.Id
-                  CollectionId = targetCollection.Id
+                { Id = encoder.Encode vocabulary.Id
+                  CollectionId = encoder.Encode targetCollection.Id
                   Name = "My Vocabulary"
                   Description = None
                   CreatedAt = createdAt
@@ -120,12 +124,18 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             use client = factory.CreateClient()
 
             let request: MoveVocabularyRequest =
-                { CollectionId = 999 }
+                { CollectionId = encoder.Encode 999 }
 
-            let! response = client.PostAsJsonAsync(Urls.Vocabularies.moveVocabularyById(1, 1), request)
+            let! response =
+                client.PostAsJsonAsync(
+                    Urls.Vocabularies.moveVocabularyById(encoder.Encode 1, encoder.Encode 1),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode)
         }
@@ -137,6 +147,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(601, "user@example.com", "P@ssw0rd!")
 
@@ -155,9 +167,13 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveVocabularyRequest =
-                { CollectionId = collection.Id }
+                { CollectionId = encoder.Encode collection.Id }
 
-            let! response = client.PostAsJsonAsync(Urls.Vocabularies.moveVocabularyById(collection.Id, 999999), request)
+            let! response =
+                client.PostAsJsonAsync(
+                    Urls.Vocabularies.moveVocabularyById(encoder.Encode collection.Id, encoder.Encode 999999),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -169,6 +185,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(602, "user@example.com", "P@ssw0rd!")
 
@@ -191,10 +209,13 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveVocabularyRequest =
-                { CollectionId = 999999 }
+                { CollectionId = encoder.Encode 999999 }
 
             let! response =
-                client.PostAsJsonAsync(Urls.Vocabularies.moveVocabularyById(collection.Id, vocabulary.Id), request)
+                client.PostAsJsonAsync(
+                    Urls.Vocabularies.moveVocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
         }
@@ -206,6 +227,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(603, "user@example.com", "P@ssw0rd!")
 
@@ -231,10 +254,13 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser)
 
             let request: MoveVocabularyRequest =
-                { CollectionId = collectionA.Id }
+                { CollectionId = encoder.Encode collectionA.Id }
 
             let! response =
-                client.PostAsJsonAsync(Urls.Vocabularies.moveVocabularyById(collectionA.Id, vocabulary.Id), request)
+                client.PostAsJsonAsync(
+                    Urls.Vocabularies.moveVocabularyById(encoder.Encode collectionA.Id, encoder.Encode vocabulary.Id),
+                    request
+                )
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode)
 
@@ -263,6 +289,8 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser1, wordfolioUser1 = factory.CreateUserAsync(604, "user1@example.com", "P@ssw0rd!")
             let! _, wordfolioUser2 = factory.CreateUserAsync(605, "user2@example.com", "P@ssw0rd!")
 
@@ -288,11 +316,14 @@ type MoveVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use! client = factory.CreateAuthenticatedClientAsync(identityUser1)
 
             let request: MoveVocabularyRequest =
-                { CollectionId = foreignCollection.Id }
+                { CollectionId = encoder.Encode foreignCollection.Id }
 
             let! response =
                 client.PostAsJsonAsync(
-                    Urls.Vocabularies.moveVocabularyById(sourceCollection.Id, vocabulary.Id),
+                    Urls.Vocabularies.moveVocabularyById(
+                        encoder.Encode sourceCollection.Id,
+                        encoder.Encode vocabulary.Id
+                    ),
                     request
                 )
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Vocabularies/UpdateVocabularyTests.fs
@@ -4,10 +4,12 @@ open System
 open System.Net
 open System.Net.Http.Json
 open System.Threading.Tasks
+open Microsoft.Extensions.DependencyInjection
 
 open Xunit
 
 open Wordfolio.Api.Api.Vocabularies.Types
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.Api.Tests
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api.Tests.Utils.Wordfolio
@@ -24,6 +26,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(205, "user@example.com", "P@ssw0rd!")
 
@@ -53,7 +57,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Updated Description" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
             let! body = response.Content.ReadAsStringAsync()
@@ -63,8 +67,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             let! actualResponse = response.Content.ReadFromJsonAsync<VocabularyResponse>()
 
             let expectedResponse: VocabularyResponse =
-                { Id = vocabulary.Id
-                  CollectionId = collection.Id
+                { Id = encoder.Encode vocabulary.Id
+                  CollectionId = encoder.Encode collection.Id
                   Name = "Updated Name"
                   Description = Some "Updated Description"
                   CreatedAt = vocabulary.CreatedAt
@@ -124,6 +128,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(206, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -145,7 +151,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Updated Description" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, 999999)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode 999999)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
 
@@ -163,6 +169,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! identityUser, wordfolioUser = factory.CreateUserAsync(217, "user@example.com", "P@ssw0rd!")
 
@@ -201,7 +209,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Updated Description" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(collectionA.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collectionA.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
 
@@ -231,6 +239,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, ownerWordfolioUser = factory.CreateUserAsync(213, "owner@example.com", "P@ssw0rd!")
 
@@ -272,7 +282,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Should not be persisted" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(ownerCollection.Id, ownerVocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode ownerCollection.Id, encoder.Encode ownerVocabulary.Id)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
 
@@ -325,6 +335,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
             use factory =
                 new WebApplicationFactory(fixture)
 
+            let encoder = factory.Encoder
+
             let! identityUser, wordfolioUser = factory.CreateUserAsync(207, "user@example.com", "P@ssw0rd!")
 
             let now =
@@ -353,7 +365,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Updated Description" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
 
@@ -383,6 +395,8 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
 
             use factory =
                 new WebApplicationFactory(fixture)
+
+            let encoder = factory.Encoder
 
             let! _, wordfolioUser = factory.CreateUserAsync(215, "user@example.com", "P@ssw0rd!")
 
@@ -418,7 +432,7 @@ type UpdateVocabularyTests(fixture: WordfolioIdentityTestFixture) =
                   Description = Some "Updated Description" }
 
             let url =
-                Urls.Vocabularies.vocabularyById(collection.Id, vocabulary.Id)
+                Urls.Vocabularies.vocabularyById(encoder.Encode collection.Id, encoder.Encode vocabulary.Id)
 
             let! response = client.PutAsJsonAsync(url, updateRequest)
 

--- a/Wordfolio.Api/Wordfolio.Api.Tests/WebApplicationFactory.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/WebApplicationFactory.fs
@@ -13,6 +13,7 @@ open Microsoft.Extensions.Hosting
 
 open Wordfolio.Api.Tests.Utils
 open Wordfolio.Api
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 type WebApplicationFactory(fixture: WordfolioIdentityTestFixture, ?configureServices: IServiceCollection -> unit) =
     inherit WebApplicationFactory<Program.Program>()
@@ -46,6 +47,9 @@ type WebApplicationFactory(fixture: WordfolioIdentityTestFixture, ?configureServ
             client.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", token)
             return client
         }
+
+    member this.Encoder: IResourceIdEncoder =
+        this.Services.GetRequiredService<IResourceIdEncoder>()
 
     member this.CreateUserAsync
         (

--- a/Wordfolio.Api/Wordfolio.Api/Api/Collections/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Collections/Handlers.fs
@@ -18,6 +18,7 @@ open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Collections
 open Wordfolio.Api.Domain.Collections.Operations
 open Wordfolio.Api.Infrastructure.Environment
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module UrlTokens = Wordfolio.Api.Urls
 module Urls = Wordfolio.Api.Urls.Collections
@@ -50,24 +51,25 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.Root,
-            Func<ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>(fun user dataSource cancellationToken ->
-                task {
-                    match getUserId user with
-                    | None -> return Results.Unauthorized()
-                    | Some userId ->
-                        let env =
-                            TransactionalEnv(dataSource, cancellationToken)
+            Func<ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun user encoder dataSource cancellationToken ->
+                    task {
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            let env =
+                                TransactionalEnv(dataSource, cancellationToken)
 
-                        let! result = getByUserId env { UserId = UserId userId }
+                            let! result = getByUserId env { UserId = UserId userId }
 
-                        let collections = okOrFail result
+                            let collections = okOrFail result
 
-                        return
-                            Results.Ok(
-                                collections
-                                |> List.map toCollectionResponse
-                            )
-                })
+                            return
+                                Results.Ok(
+                                    collections
+                                    |> List.map(toCollectionResponse encoder)
+                                )
+                    })
         )
         .Produces<CollectionResponse list>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
@@ -76,12 +78,13 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.ById,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -89,11 +92,11 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
                                 getById
                                     env
                                     { UserId = UserId userId
-                                      CollectionId = CollectionId id }
+                                      CollectionId = CollectionId collectionId }
 
                             return
                                 match result with
-                                | Ok collection -> Results.Ok(toCollectionResponse collection)
+                                | Ok collection -> Results.Ok(toCollectionResponse encoder collection)
                                 | Error error -> toGetByIdErrorResponse error
                     })
         )
@@ -106,8 +109,8 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.Root,
-            Func<CreateCollectionRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun request user dataSource cancellationToken ->
+            Func<CreateCollectionRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun request user encoder dataSource cancellationToken ->
                     task {
                         match getUserId user with
                         | None -> return Results.Unauthorized()
@@ -126,10 +129,10 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
                             return
                                 match result with
                                 | Ok collection ->
-                                    Results.Created(
-                                        Urls.collectionById(CollectionId.value collection.Id),
-                                        toCollectionResponse collection
-                                    )
+                                    let response =
+                                        toCollectionResponse encoder collection
+
+                                    Results.Created(Urls.collectionById response.Id, response)
                                 | Error error -> toCreateErrorResponse error
                     })
         )
@@ -141,12 +144,13 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
     group
         .MapPut(
             UrlTokens.ById,
-            Func<int, UpdateCollectionRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id request user dataSource cancellationToken ->
+            Func<string, UpdateCollectionRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -154,14 +158,14 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
                                 update
                                     env
                                     { UserId = UserId userId
-                                      CollectionId = CollectionId id
+                                      CollectionId = CollectionId collectionId
                                       Name = request.Name
                                       Description = request.Description
                                       UpdatedAt = DateTimeOffset.UtcNow }
 
                             return
                                 match result with
-                                | Ok collection -> Results.Ok(toCollectionResponse collection)
+                                | Ok collection -> Results.Ok(toCollectionResponse encoder collection)
                                 | Error error -> toUpdateErrorResponse error
                     })
         )
@@ -175,12 +179,13 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
     group
         .MapDelete(
             UrlTokens.ById,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -188,7 +193,7 @@ let mapCollectionsEndpoints(group: RouteGroupBuilder) =
                                 delete
                                     env
                                     { UserId = UserId userId
-                                      CollectionId = CollectionId id }
+                                      CollectionId = CollectionId collectionId }
 
                             return
                                 match result with

--- a/Wordfolio.Api/Wordfolio.Api/Api/Collections/Mappers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Collections/Mappers.fs
@@ -2,9 +2,10 @@ module Wordfolio.Api.Api.Collections.Mappers
 
 open Wordfolio.Api.Api.Collections.Types
 open Wordfolio.Api.Domain
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
-let toCollectionResponse(collection: Collection) : CollectionResponse =
-    { Id = CollectionId.value collection.Id
+let toCollectionResponse (encoder: IResourceIdEncoder) (collection: Collection) : CollectionResponse =
+    { Id = encoder.Encode(CollectionId.value collection.Id)
       Name = collection.Name
       Description = collection.Description
       CreatedAt = collection.CreatedAt

--- a/Wordfolio.Api/Wordfolio.Api/Api/Collections/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Collections/Types.fs
@@ -3,7 +3,7 @@ module Wordfolio.Api.Api.Collections.Types
 open System
 
 type CollectionResponse =
-    { Id: int
+    { Id: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset

--- a/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Handlers.fs
@@ -18,6 +18,7 @@ open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.CollectionsHierarchy
 open Wordfolio.Api.Domain.CollectionsHierarchy.Operations
 open Wordfolio.Api.Infrastructure.Environment
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module UrlTokens = Wordfolio.Api.Urls
 module Urls = Wordfolio.Api.Urls.CollectionsHierarchy
@@ -26,28 +27,29 @@ let mapCollectionsHierarchyEndpoints(group: IEndpointRouteBuilder) =
     group
         .MapGet(
             UrlTokens.Root,
-            Func<ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>(fun user dataSource cancellationToken ->
-                task {
-                    match getUserId user with
-                    | None -> return Results.Unauthorized()
-                    | Some userId ->
-                        let env =
-                            TransactionalEnv(dataSource, cancellationToken)
+            Func<ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun user encoder dataSource cancellationToken ->
+                    task {
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            let env =
+                                TransactionalEnv(dataSource, cancellationToken)
 
-                        let! result = getByUserId env { UserId = UserId userId }
+                            let! result = getByUserId env { UserId = UserId userId }
 
-                        let hierarchyResult = okOrFail result
+                            let hierarchyResult = okOrFail result
 
-                        let response: CollectionsHierarchyResultResponse =
-                            { Collections =
-                                hierarchyResult.Collections
-                                |> List.map toCollectionWithVocabulariesResponse
-                              DefaultVocabulary =
-                                hierarchyResult.DefaultVocabulary
-                                |> Option.map toVocabularyWithEntryCountResponse }
+                            let response: CollectionsHierarchyResultResponse =
+                                { Collections =
+                                    hierarchyResult.Collections
+                                    |> List.map(toCollectionWithVocabulariesResponse encoder)
+                                  DefaultVocabulary =
+                                    hierarchyResult.DefaultVocabulary
+                                    |> Option.map(toVocabularyWithEntryCountResponse encoder) }
 
-                        return Results.Ok(response)
-                })
+                            return Results.Ok(response)
+                    })
         )
         .Produces<CollectionsHierarchyResultResponse>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
@@ -56,23 +58,24 @@ let mapCollectionsHierarchyEndpoints(group: IEndpointRouteBuilder) =
     group
         .MapGet(
             Urls.CollectionsPath,
-            Func<ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>(fun user dataSource cancellationToken ->
-                task {
-                    match getUserId user with
-                    | None -> return Results.Unauthorized()
-                    | Some userId ->
-                        let env =
-                            TransactionalEnv(dataSource, cancellationToken)
+            Func<ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun user encoder dataSource cancellationToken ->
+                    task {
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            let env =
+                                TransactionalEnv(dataSource, cancellationToken)
 
-                        let! result = getCollectionsWithVocabularyCount env (UserId userId)
+                            let! result = getCollectionsWithVocabularyCount env (UserId userId)
 
-                        let collections = okOrFail result
+                            let collections = okOrFail result
 
-                        return
-                            collections
-                            |> List.map toCollectionWithVocabularyCountResponse
-                            |> Results.Ok
-                })
+                            return
+                                collections
+                                |> List.map(toCollectionWithVocabularyCountResponse encoder)
+                                |> Results.Ok
+                    })
         )
         .Produces<CollectionWithVocabularyCountResponse list>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
@@ -81,12 +84,13 @@ let mapCollectionsHierarchyEndpoints(group: IEndpointRouteBuilder) =
     group
         .MapGet(
             Urls.VocabulariesByCollectionPath,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -100,7 +104,7 @@ let mapCollectionsHierarchyEndpoints(group: IEndpointRouteBuilder) =
 
                             return
                                 vocabularies
-                                |> List.map toVocabularyWithEntryCountResponse
+                                |> List.map(toVocabularyWithEntryCountResponse encoder)
                                 |> Results.Ok
                     })
         )

--- a/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Mappers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Mappers.fs
@@ -3,29 +3,37 @@ module Wordfolio.Api.Api.CollectionsHierarchy.Mappers
 open Wordfolio.Api.Api.CollectionsHierarchy.Types
 open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.CollectionsHierarchy
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
-let toVocabularyWithEntryCountResponse(vocabulary: VocabularyWithEntryCount) : VocabularyWithEntryCountResponse =
-    { Id = VocabularyId.value vocabulary.Id
+let toVocabularyWithEntryCountResponse
+    (encoder: IResourceIdEncoder)
+    (vocabulary: VocabularyWithEntryCount)
+    : VocabularyWithEntryCountResponse =
+    { Id = encoder.Encode(VocabularyId.value vocabulary.Id)
       Name = vocabulary.Name
       Description = vocabulary.Description
       CreatedAt = vocabulary.CreatedAt
       UpdatedAt = vocabulary.UpdatedAt
       EntryCount = vocabulary.EntryCount }
 
-let toCollectionWithVocabulariesResponse(collection: CollectionWithVocabularies) : CollectionWithVocabulariesResponse =
-    { Id = CollectionId.value collection.Id
+let toCollectionWithVocabulariesResponse
+    (encoder: IResourceIdEncoder)
+    (collection: CollectionWithVocabularies)
+    : CollectionWithVocabulariesResponse =
+    { Id = encoder.Encode(CollectionId.value collection.Id)
       Name = collection.Name
       Description = collection.Description
       CreatedAt = collection.CreatedAt
       UpdatedAt = collection.UpdatedAt
       Vocabularies =
         collection.Vocabularies
-        |> List.map toVocabularyWithEntryCountResponse }
+        |> List.map(toVocabularyWithEntryCountResponse encoder) }
 
 let toCollectionWithVocabularyCountResponse
+    (encoder: IResourceIdEncoder)
     (collection: CollectionWithVocabularyCount)
     : CollectionWithVocabularyCountResponse =
-    { Id = CollectionId.value collection.Id
+    { Id = encoder.Encode(CollectionId.value collection.Id)
       Name = collection.Name
       Description = collection.Description
       CreatedAt = collection.CreatedAt

--- a/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/CollectionsHierarchy/Types.fs
@@ -3,7 +3,7 @@ module Wordfolio.Api.Api.CollectionsHierarchy.Types
 open System
 
 type VocabularyWithEntryCountResponse =
-    { Id: int
+    { Id: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
@@ -11,7 +11,7 @@ type VocabularyWithEntryCountResponse =
       EntryCount: int }
 
 type CollectionWithVocabulariesResponse =
-    { Id: int
+    { Id: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
@@ -19,7 +19,7 @@ type CollectionWithVocabulariesResponse =
       Vocabularies: VocabularyWithEntryCountResponse list }
 
 type CollectionWithVocabularyCountResponse =
-    { Id: int
+    { Id: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset

--- a/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Handlers.fs
@@ -19,11 +19,12 @@ open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Entries
 open Wordfolio.Api.Domain.Entries.DraftOperations
 open Wordfolio.Api.Infrastructure.Environment
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module UrlTokens = Wordfolio.Api.Urls
 module Urls = Wordfolio.Api.Urls.Drafts
 
-let private toCreateErrorResponse(error: CreateDraftEntryError) : IResult =
+let private toCreateErrorResponse (encoder: IResourceIdEncoder) (error: CreateDraftEntryError) : IResult =
     match error with
     | CreateDraftEntryError.EntryTextRequired -> Results.BadRequest({| error = "Entry text is required" |})
     | CreateDraftEntryError.EntryTextTooLong maxLength ->
@@ -31,7 +32,7 @@ let private toCreateErrorResponse(error: CreateDraftEntryError) : IResult =
     | CreateDraftEntryError.DuplicateEntry existingEntry ->
         Results.Conflict(
             {| error = "A matching entry already exists in this vocabulary"
-               existingEntry = toEntryResponse existingEntry |}
+               existingEntry = toEntryResponse encoder existingEntry |}
         )
     | CreateDraftEntryError.NoDefinitionsOrTranslations ->
         Results.BadRequest({| error = "At least one definition or translation required" |})
@@ -70,23 +71,24 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             Urls.All,
-            Func<ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>(fun user dataSource cancellationToken ->
-                task {
-                    match getUserId user with
-                    | None -> return Results.Unauthorized()
-                    | Some userId ->
-                        let env =
-                            TransactionalEnv(dataSource, cancellationToken)
+            Func<ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun user encoder dataSource cancellationToken ->
+                    task {
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            let env =
+                                TransactionalEnv(dataSource, cancellationToken)
 
-                        let! result = getDrafts env { UserId = UserId userId }
+                            let! result = getDrafts env { UserId = UserId userId }
 
-                        let drafts = okOrFail result
+                            let drafts = okOrFail result
 
-                        return
-                            match drafts with
-                            | None -> Results.NotFound()
-                            | Some data -> Results.Ok(toDraftsVocabularyDataResponse data)
-                })
+                            return
+                                match drafts with
+                                | None -> Results.NotFound()
+                                | Some data -> Results.Ok(toDraftsVocabularyDataResponse encoder data)
+                    })
         )
         .RequireAuthorization()
         .Produces<DraftsVocabularyDataResponse>(StatusCodes.Status200OK)
@@ -97,8 +99,8 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.Root,
-            Func<CreateDraftRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun request user dataSource cancellationToken ->
+            Func<CreateDraftRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun request user encoder dataSource cancellationToken ->
                     task {
                         match getUserId user with
                         | None -> return Results.Unauthorized()
@@ -125,8 +127,10 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
                             return
                                 match result with
                                 | Ok entry ->
-                                    Results.Created(Urls.draftById(EntryId.value entry.Id), toEntryResponse entry)
-                                | Error error -> toCreateErrorResponse error
+                                    let response = toEntryResponse encoder entry
+
+                                    Results.Created(Urls.draftById response.Id, response)
+                                | Error error -> toCreateErrorResponse encoder error
                     })
         )
         .RequireAuthorization()
@@ -139,12 +143,13 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.ById,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -156,7 +161,7 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toGetByIdErrorResponse error
                     })
         )
@@ -169,12 +174,13 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapPut(
             UrlTokens.ById,
-            Func<int, UpdateEntryRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id request user dataSource cancellationToken ->
+            Func<string, UpdateEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -198,7 +204,7 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toUpdateErrorResponse error
                     })
         )
@@ -212,12 +218,13 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapDelete(
             UrlTokens.ById,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -242,12 +249,14 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.ById + Urls.Move,
-            Func<int, MoveDraftRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun id request user dataSource cancellationToken ->
+            Func<string, MoveDraftRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(id), encoder.Decode(request.VocabularyId) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some id, Some targetVocabularyId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -256,12 +265,12 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
                                     env
                                     { UserId = UserId userId
                                       EntryId = EntryId id
-                                      TargetVocabularyId = VocabularyId request.VocabularyId
+                                      TargetVocabularyId = VocabularyId targetVocabularyId
                                       UpdatedAt = DateTimeOffset.UtcNow }
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toMoveErrorResponse error
                     })
         )

--- a/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Handlers.fs
@@ -252,26 +252,27 @@ let mapDraftsEndpoints(group: RouteGroupBuilder) =
             Func<string, MoveDraftRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(id), encoder.Decode(request.VocabularyId) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some id, Some targetVocabularyId ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, id, request.VocabularyId) with
+                            | None -> return Results.NotFound()
+                            | Some(id, targetVocabularyId) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                move
-                                    env
-                                    { UserId = UserId userId
-                                      EntryId = EntryId id
-                                      TargetVocabularyId = VocabularyId targetVocabularyId
-                                      UpdatedAt = DateTimeOffset.UtcNow }
+                                let! result =
+                                    move
+                                        env
+                                        { UserId = UserId userId
+                                          EntryId = EntryId id
+                                          TargetVocabularyId = VocabularyId targetVocabularyId
+                                          UpdatedAt = DateTimeOffset.UtcNow }
 
-                            return
-                                match result with
-                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
-                                | Error error -> toMoveErrorResponse error
+                                return
+                                    match result with
+                                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
+                                    | Error error -> toMoveErrorResponse error
                     })
         )
         .RequireAuthorization()

--- a/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Mappers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Mappers.fs
@@ -4,16 +4,20 @@ open Wordfolio.Api.Api.Drafts.Types
 open Wordfolio.Api.Api.Mappers
 open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Entries
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
-let private toVocabularyResponse(vocabulary: Vocabulary) : VocabularyResponse =
-    { Id = VocabularyId.value vocabulary.Id
+let private toVocabularyResponse (encoder: IResourceIdEncoder) (vocabulary: Vocabulary) : VocabularyResponse =
+    { Id = encoder.Encode(VocabularyId.value vocabulary.Id)
       Name = vocabulary.Name
       Description = vocabulary.Description
       CreatedAt = vocabulary.CreatedAt
       UpdatedAt = vocabulary.UpdatedAt }
 
-let toDraftsVocabularyDataResponse(drafts: DraftsVocabularyData) : DraftsVocabularyDataResponse =
-    { Vocabulary = toVocabularyResponse drafts.Vocabulary
+let toDraftsVocabularyDataResponse
+    (encoder: IResourceIdEncoder)
+    (drafts: DraftsVocabularyData)
+    : DraftsVocabularyDataResponse =
+    { Vocabulary = toVocabularyResponse encoder drafts.Vocabulary
       Entries =
         drafts.Entries
-        |> List.map toEntryResponse }
+        |> List.map(toEntryResponse encoder) }

--- a/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Drafts/Types.fs
@@ -10,10 +10,10 @@ type CreateDraftRequest =
       Translations: TranslationRequest list
       AllowDuplicate: bool option }
 
-type MoveDraftRequest = { VocabularyId: int }
+type MoveDraftRequest = { VocabularyId: string }
 
 type VocabularyResponse =
-    { Id: int
+    { Id: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset

--- a/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
@@ -301,8 +301,7 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
 
                             match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
                             | None -> return Results.NotFound()
-                            | Some(collectionId, vocabularyId, id) when not targetVocabularyIdValid ->
-                                return Results.NotFound()
+                            | _ when not targetVocabularyIdValid -> return Results.NotFound()
                             | Some(collectionId, vocabularyId, id) ->
                                 let env =
                                     TransactionalEnv(dataSource, cancellationToken)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
@@ -19,6 +19,7 @@ open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Entries
 open Wordfolio.Api.Domain.Entries.EntryOperations
 open Wordfolio.Api.Infrastructure.Environment
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module UrlTokens = Wordfolio.Api.Urls
 module Urls = Wordfolio.Api.Urls.Entries
@@ -28,7 +29,7 @@ let private toGetByVocabularyIdErrorResponse(error: GetEntriesByVocabularyIdErro
     | GetEntriesByVocabularyIdError.VocabularyNotFoundOrAccessDenied _ ->
         Results.NotFound({| error = "Vocabulary not found" |})
 
-let private toCreateErrorResponse(error: CreateEntryError) : IResult =
+let private toCreateErrorResponse (encoder: IResourceIdEncoder) (error: CreateEntryError) : IResult =
     match error with
     | CreateEntryError.EntryTextRequired -> Results.BadRequest({| error = "Entry text is required" |})
     | CreateEntryError.EntryTextTooLong maxLength ->
@@ -37,7 +38,7 @@ let private toCreateErrorResponse(error: CreateEntryError) : IResult =
     | CreateEntryError.DuplicateEntry existingEntry ->
         Results.Conflict(
             {| error = "A matching entry already exists in this vocabulary"
-               existingEntry = toEntryResponse existingEntry |}
+               existingEntry = toEntryResponse encoder existingEntry |}
         )
     | CreateEntryError.NoDefinitionsOrTranslations ->
         Results.BadRequest({| error = "At least one definition or translation required" |})
@@ -79,12 +80,14 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.Root,
-            Func<int, int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId user dataSource cancellationToken ->
+            Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(vocabularyId) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some vocabularyId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -99,7 +102,8 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
                                 match result with
                                 | Ok entries ->
                                     let response =
-                                        entries |> List.map toEntryResponse
+                                        entries
+                                        |> List.map(toEntryResponse encoder)
 
                                     Results.Ok(response)
                                 | Error error -> toGetByVocabularyIdErrorResponse error
@@ -113,19 +117,21 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.Root,
-            Func<int, int, CreateEntryRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId request user dataSource cancellationToken ->
+            Func<string, string, CreateEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(vocabularyId) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some decodedCollectionId, Some decodedVocabularyId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
                             let parameters: CreateParameters =
                                 { UserId = UserId userId
-                                  CollectionId = CollectionId collectionId
-                                  VocabularyId = VocabularyId vocabularyId
+                                  CollectionId = CollectionId decodedCollectionId
+                                  VocabularyId = VocabularyId decodedVocabularyId
                                   EntryText = request.EntryText
                                   Definitions =
                                     request.Definitions
@@ -143,11 +149,10 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
                             return
                                 match result with
                                 | Ok entry ->
-                                    Results.Created(
-                                        Urls.entryById(collectionId, vocabularyId, EntryId.value entry.Id),
-                                        toEntryResponse entry
-                                    )
-                                | Error error -> toCreateErrorResponse error
+                                    let response = toEntryResponse encoder entry
+
+                                    Results.Created(Urls.entryById(collectionId, vocabularyId, response.Id), response)
+                                | Error error -> toCreateErrorResponse encoder error
                     })
         )
         .Produces<EntryResponse>(StatusCodes.Status201Created)
@@ -160,12 +165,20 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.ById,
-            Func<int, int, int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId id user dataSource cancellationToken ->
+            Func<string, string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match
+                            getUserId user,
+                            encoder.Decode(collectionId),
+                            encoder.Decode(vocabularyId),
+                            encoder.Decode(id)
+                        with
+                        | None, _, _, _ -> return Results.Unauthorized()
+                        | _, None, _, _
+                        | _, _, None, _
+                        | _, _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -179,7 +192,7 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toGetByIdErrorResponse error
                     })
         )
@@ -191,12 +204,20 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapDelete(
             UrlTokens.ById,
-            Func<int, int, int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId id user dataSource cancellationToken ->
+            Func<string, string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match
+                            getUserId user,
+                            encoder.Decode(collectionId),
+                            encoder.Decode(vocabularyId),
+                            encoder.Decode(id)
+                        with
+                        | None, _, _, _ -> return Results.Unauthorized()
+                        | _, None, _, _
+                        | _, _, None, _
+                        | _, _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -222,12 +243,20 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPut(
             UrlTokens.ById,
-            Func<int, int, int, UpdateEntryRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId id request user dataSource cancellationToken ->
+            Func<string, string, string, UpdateEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match
+                            getUserId user,
+                            encoder.Decode(collectionId),
+                            encoder.Decode(vocabularyId),
+                            encoder.Decode(id)
+                        with
+                        | None, _, _, _ -> return Results.Unauthorized()
+                        | _, None, _, _
+                        | _, _, None, _
+                        | _, _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -253,7 +282,7 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toUpdateErrorResponse error
                     })
         )
@@ -266,12 +295,30 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.ById + "/move",
-            Func<int, int, int, MoveEntryRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId vocabularyId id request user dataSource cancellationToken ->
+            Func<string, string, string, MoveEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId vocabularyId id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        let decodedTargetVocabularyId =
+                            request.VocabularyId
+                            |> Option.bind encoder.Decode
+
+                        let targetVocabularyIdValid =
+                            request.VocabularyId.IsNone
+                            || decodedTargetVocabularyId.IsSome
+
+                        match
+                            getUserId user,
+                            encoder.Decode(collectionId),
+                            encoder.Decode(vocabularyId),
+                            encoder.Decode(id),
+                            targetVocabularyIdValid
+                        with
+                        | None, _, _, _, _ -> return Results.Unauthorized()
+                        | _, None, _, _, _
+                        | _, _, None, _, _
+                        | _, _, _, None, _
+                        | _, _, _, _, false -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some vocabularyId, Some id, _ ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -283,13 +330,13 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
                                       VocabularyId = VocabularyId vocabularyId
                                       EntryId = EntryId id
                                       TargetVocabularyId =
-                                        request.VocabularyId
+                                        decodedTargetVocabularyId
                                         |> Option.map VocabularyId
                                       UpdatedAt = DateTimeOffset.UtcNow }
 
                             return
                                 match result with
-                                | Ok entry -> Results.Ok(toEntryResponse entry)
+                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
                                 | Error error -> toMoveErrorResponse error
                     })
         )

--- a/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
@@ -83,30 +83,31 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(vocabularyId) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some vocabularyId ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, vocabularyId) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                getByVocabularyId
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId vocabularyId }
+                                let! result =
+                                    getByVocabularyId
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId vocabularyId }
 
-                            return
-                                match result with
-                                | Ok entries ->
-                                    let response =
-                                        entries
-                                        |> List.map(toEntryResponse encoder)
+                                return
+                                    match result with
+                                    | Ok entries ->
+                                        let response =
+                                            entries
+                                            |> List.map(toEntryResponse encoder)
 
-                                    Results.Ok(response)
-                                | Error error -> toGetByVocabularyIdErrorResponse error
+                                        Results.Ok(response)
+                                    | Error error -> toGetByVocabularyIdErrorResponse error
                     })
         )
         .Produces<EntryResponse list>(StatusCodes.Status200OK)
@@ -120,39 +121,43 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, CreateEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(vocabularyId) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some decodedCollectionId, Some decodedVocabularyId ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId) with
+                            | None -> return Results.NotFound()
+                            | Some(decodedCollectionId, decodedVocabularyId) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let parameters: CreateParameters =
-                                { UserId = UserId userId
-                                  CollectionId = CollectionId decodedCollectionId
-                                  VocabularyId = VocabularyId decodedVocabularyId
-                                  EntryText = request.EntryText
-                                  Definitions =
-                                    request.Definitions
-                                    |> List.map toDefinitionInput
-                                  Translations =
-                                    request.Translations
-                                    |> List.map toTranslationInput
-                                  AllowDuplicate =
-                                    request.AllowDuplicate
-                                    |> Option.defaultValue false
-                                  CreatedAt = DateTimeOffset.UtcNow }
+                                let parameters: CreateParameters =
+                                    { UserId = UserId userId
+                                      CollectionId = CollectionId decodedCollectionId
+                                      VocabularyId = VocabularyId decodedVocabularyId
+                                      EntryText = request.EntryText
+                                      Definitions =
+                                        request.Definitions
+                                        |> List.map toDefinitionInput
+                                      Translations =
+                                        request.Translations
+                                        |> List.map toTranslationInput
+                                      AllowDuplicate =
+                                        request.AllowDuplicate
+                                        |> Option.defaultValue false
+                                      CreatedAt = DateTimeOffset.UtcNow }
 
-                            let! result = create env parameters
+                                let! result = create env parameters
 
-                            return
-                                match result with
-                                | Ok entry ->
-                                    let response = toEntryResponse encoder entry
+                                return
+                                    match result with
+                                    | Ok entry ->
+                                        let response = toEntryResponse encoder entry
 
-                                    Results.Created(Urls.entryById(collectionId, vocabularyId, response.Id), response)
-                                | Error error -> toCreateErrorResponse encoder error
+                                        Results.Created(
+                                            Urls.entryById(collectionId, vocabularyId, response.Id),
+                                            response
+                                        )
+                                    | Error error -> toCreateErrorResponse encoder error
                     })
         )
         .Produces<EntryResponse>(StatusCodes.Status201Created)
@@ -168,32 +173,27 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId id user encoder dataSource cancellationToken ->
                     task {
-                        match
-                            getUserId user,
-                            encoder.Decode(collectionId),
-                            encoder.Decode(vocabularyId),
-                            encoder.Decode(id)
-                        with
-                        | None, _, _, _ -> return Results.Unauthorized()
-                        | _, None, _, _
-                        | _, _, None, _
-                        | _, _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, vocabularyId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                getById
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId vocabularyId
-                                      EntryId = EntryId id }
+                                let! result =
+                                    getById
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId vocabularyId
+                                          EntryId = EntryId id }
 
-                            return
-                                match result with
-                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
-                                | Error error -> toGetByIdErrorResponse error
+                                return
+                                    match result with
+                                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
+                                    | Error error -> toGetByIdErrorResponse error
                     })
         )
         .Produces<EntryResponse>(StatusCodes.Status200OK)
@@ -207,32 +207,27 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId id user encoder dataSource cancellationToken ->
                     task {
-                        match
-                            getUserId user,
-                            encoder.Decode(collectionId),
-                            encoder.Decode(vocabularyId),
-                            encoder.Decode(id)
-                        with
-                        | None, _, _, _ -> return Results.Unauthorized()
-                        | _, None, _, _
-                        | _, _, None, _
-                        | _, _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, vocabularyId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                delete
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId vocabularyId
-                                      EntryId = EntryId id }
+                                let! result =
+                                    delete
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId vocabularyId
+                                          EntryId = EntryId id }
 
-                            return
-                                match result with
-                                | Ok() -> Results.NoContent()
-                                | Error error -> toDeleteErrorResponse error
+                                return
+                                    match result with
+                                    | Ok() -> Results.NoContent()
+                                    | Error error -> toDeleteErrorResponse error
                     })
         )
         .Produces(StatusCodes.Status204NoContent)
@@ -246,44 +241,39 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, string, UpdateEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId id request user encoder dataSource cancellationToken ->
                     task {
-                        match
-                            getUserId user,
-                            encoder.Decode(collectionId),
-                            encoder.Decode(vocabularyId),
-                            encoder.Decode(id)
-                        with
-                        | None, _, _, _ -> return Results.Unauthorized()
-                        | _, None, _, _
-                        | _, _, None, _
-                        | _, _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some vocabularyId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, vocabularyId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let definitions =
-                                request.Definitions
-                                |> List.map toDefinitionInput
+                                let definitions =
+                                    request.Definitions
+                                    |> List.map toDefinitionInput
 
-                            let translations =
-                                request.Translations
-                                |> List.map toTranslationInput
+                                let translations =
+                                    request.Translations
+                                    |> List.map toTranslationInput
 
-                            let! result =
-                                update
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId vocabularyId
-                                      EntryId = EntryId id
-                                      EntryText = request.EntryText
-                                      Definitions = definitions
-                                      Translations = translations
-                                      UpdatedAt = DateTimeOffset.UtcNow }
+                                let! result =
+                                    update
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId vocabularyId
+                                          EntryId = EntryId id
+                                          EntryText = request.EntryText
+                                          Definitions = definitions
+                                          Translations = translations
+                                          UpdatedAt = DateTimeOffset.UtcNow }
 
-                            return
-                                match result with
-                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
-                                | Error error -> toUpdateErrorResponse error
+                                return
+                                    match result with
+                                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
+                                    | Error error -> toUpdateErrorResponse error
                     })
         )
         .Produces<EntryResponse>(StatusCodes.Status200OK)
@@ -298,46 +288,41 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, string, MoveEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId id request user encoder dataSource cancellationToken ->
                     task {
-                        let decodedTargetVocabularyId =
-                            request.VocabularyId
-                            |> Option.bind encoder.Decode
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            let decodedTargetVocabularyId =
+                                request.VocabularyId
+                                |> Option.bind encoder.Decode
 
-                        let targetVocabularyIdValid =
-                            request.VocabularyId.IsNone
-                            || decodedTargetVocabularyId.IsSome
+                            let targetVocabularyIdValid =
+                                request.VocabularyId.IsNone
+                                || decodedTargetVocabularyId.IsSome
 
-                        match
-                            getUserId user,
-                            encoder.Decode(collectionId),
-                            encoder.Decode(vocabularyId),
-                            encoder.Decode(id),
-                            targetVocabularyIdValid
-                        with
-                        | None, _, _, _, _ -> return Results.Unauthorized()
-                        | _, None, _, _, _
-                        | _, _, None, _, _
-                        | _, _, _, None, _
-                        | _, _, _, _, false -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some vocabularyId, Some id, _ ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, vocabularyId, id) when not targetVocabularyIdValid ->
+                                return Results.NotFound()
+                            | Some(collectionId, vocabularyId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                move
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId vocabularyId
-                                      EntryId = EntryId id
-                                      TargetVocabularyId =
-                                        decodedTargetVocabularyId
-                                        |> Option.map VocabularyId
-                                      UpdatedAt = DateTimeOffset.UtcNow }
+                                let! result =
+                                    move
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId vocabularyId
+                                          EntryId = EntryId id
+                                          TargetVocabularyId =
+                                            decodedTargetVocabularyId
+                                            |> Option.map VocabularyId
+                                          UpdatedAt = DateTimeOffset.UtcNow }
 
-                            return
-                                match result with
-                                | Ok entry -> Results.Ok(toEntryResponse encoder entry)
-                                | Error error -> toMoveErrorResponse error
+                                return
+                                    match result with
+                                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
+                                    | Error error -> toMoveErrorResponse error
                     })
         )
         .Produces<EntryResponse>(StatusCodes.Status200OK)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Entries/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Entries/Types.fs
@@ -8,4 +8,4 @@ type CreateEntryRequest =
       Translations: TranslationRequest list
       AllowDuplicate: bool option }
 
-type MoveEntryRequest = { VocabularyId: int option }
+type MoveEntryRequest = { VocabularyId: string option }

--- a/Wordfolio.Api/Wordfolio.Api/Api/Helpers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Helpers.fs
@@ -3,6 +3,8 @@ module Wordfolio.Api.Api.Helpers
 open System
 open System.Security.Claims
 
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
+
 let getUserId(user: ClaimsPrincipal) : int option =
     let claim =
         user.FindFirst(ClaimTypes.NameIdentifier)
@@ -18,3 +20,14 @@ let okOrFail(result: Result<'Value, unit>) : 'Value =
     match result with
     | Ok value -> value
     | Error() -> failwith "Expected value to be Ok, but got Error"
+
+type ResourceIdsHelper =
+    static member Decode(encoder: IResourceIdEncoder, a: string, b: string) =
+        match encoder.Decode(a), encoder.Decode(b) with
+        | Some a, Some b -> Some(a, b)
+        | _ -> None
+
+    static member Decode(encoder: IResourceIdEncoder, a: string, b: string, c: string) =
+        match encoder.Decode(a), encoder.Decode(b), encoder.Decode(c) with
+        | Some a, Some b, Some c -> Some(a, b, c)
+        | _ -> None

--- a/Wordfolio.Api/Wordfolio.Api/Api/Mappers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Mappers.fs
@@ -3,6 +3,7 @@ module Wordfolio.Api.Api.Mappers
 open Wordfolio.Api.Api.Types
 open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Entries
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module ApiTypes = Wordfolio.Api.Api.Types
 
@@ -57,38 +58,38 @@ let toTranslationInput(request: TranslationRequest) : TranslationInput =
         request.Examples
         |> List.map toExampleInput }
 
-let private toExampleResponse(example: Example) : ExampleResponse =
-    { Id = ExampleId.value example.Id
+let private toExampleResponse (encoder: IResourceIdEncoder) (example: Example) : ExampleResponse =
+    { Id = encoder.Encode(ExampleId.value example.Id)
       ExampleText = example.ExampleText
       Source = toExampleSourceDto example.Source }
 
-let private toDefinitionResponse(definition: Definition) : DefinitionResponse =
-    { Id = DefinitionId.value definition.Id
+let private toDefinitionResponse (encoder: IResourceIdEncoder) (definition: Definition) : DefinitionResponse =
+    { Id = encoder.Encode(DefinitionId.value definition.Id)
       DefinitionText = definition.DefinitionText
       Source = toDefinitionSourceDto definition.Source
       DisplayOrder = definition.DisplayOrder
       Examples =
         definition.Examples
-        |> List.map toExampleResponse }
+        |> List.map(toExampleResponse encoder) }
 
-let private toTranslationResponse(translation: Translation) : TranslationResponse =
-    { Id = TranslationId.value translation.Id
+let private toTranslationResponse (encoder: IResourceIdEncoder) (translation: Translation) : TranslationResponse =
+    { Id = encoder.Encode(TranslationId.value translation.Id)
       TranslationText = translation.TranslationText
       Source = toTranslationSourceDto translation.Source
       DisplayOrder = translation.DisplayOrder
       Examples =
         translation.Examples
-        |> List.map toExampleResponse }
+        |> List.map(toExampleResponse encoder) }
 
-let toEntryResponse(entry: Entry) : EntryResponse =
-    { Id = EntryId.value entry.Id
-      VocabularyId = VocabularyId.value entry.VocabularyId
+let toEntryResponse (encoder: IResourceIdEncoder) (entry: Entry) : EntryResponse =
+    { Id = encoder.Encode(EntryId.value entry.Id)
+      VocabularyId = encoder.Encode(VocabularyId.value entry.VocabularyId)
       EntryText = entry.EntryText
       CreatedAt = entry.CreatedAt
       UpdatedAt = entry.UpdatedAt
       Definitions =
         entry.Definitions
-        |> List.map toDefinitionResponse
+        |> List.map(toDefinitionResponse encoder)
       Translations =
         entry.Translations
-        |> List.map toTranslationResponse }
+        |> List.map(toTranslationResponse encoder) }

--- a/Wordfolio.Api/Wordfolio.Api/Api/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Types.fs
@@ -38,13 +38,13 @@ type UpdateEntryRequest =
       Translations: TranslationRequest list }
 
 type ExampleResponse =
-    { Id: int
+    { Id: string
       ExampleText: string
       [<JsonConverter(typeof<JsonStringEnumConverter>)>]
       Source: ExampleSource }
 
 type DefinitionResponse =
-    { Id: int
+    { Id: string
       DefinitionText: string
       [<JsonConverter(typeof<JsonStringEnumConverter>)>]
       Source: DefinitionSource
@@ -52,7 +52,7 @@ type DefinitionResponse =
       Examples: ExampleResponse list }
 
 type TranslationResponse =
-    { Id: int
+    { Id: string
       TranslationText: string
       [<JsonConverter(typeof<JsonStringEnumConverter>)>]
       Source: TranslationSource
@@ -60,8 +60,8 @@ type TranslationResponse =
       Examples: ExampleResponse list }
 
 type EntryResponse =
-    { Id: int
-      VocabularyId: int
+    { Id: string
+      VocabularyId: string
       EntryText: string
       CreatedAt: DateTimeOffset
       UpdatedAt: DateTimeOffset

--- a/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Handlers.fs
@@ -18,6 +18,7 @@ open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Vocabularies
 open Wordfolio.Api.Domain.Vocabularies.Operations
 open Wordfolio.Api.Infrastructure.Environment
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
 module UrlTokens = Wordfolio.Api.Urls
 module Urls = Wordfolio.Api.Urls.Vocabularies
@@ -63,12 +64,13 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.Root,
-            Func<int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId user dataSource cancellationToken ->
+            Func<string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -83,7 +85,7 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
                                 | Ok vocabularies ->
                                     let response =
                                         vocabularies
-                                        |> List.map toVocabularyResponse
+                                        |> List.map(toVocabularyResponse encoder)
 
                                     Results.Ok(response)
                                 | Error error -> toGetByCollectionIdErrorResponse error
@@ -97,12 +99,13 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.Root,
-            Func<int, CreateVocabularyRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId request user dataSource cancellationToken ->
+            Func<string, CreateVocabularyRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId) with
+                        | None, _ -> return Results.Unauthorized()
+                        | _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -118,10 +121,10 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
                             return
                                 match result with
                                 | Ok vocabulary ->
-                                    Results.Created(
-                                        Urls.vocabularyById(collectionId, VocabularyId.value vocabulary.Id),
-                                        toVocabularyResponse vocabulary
-                                    )
+                                    let response =
+                                        toVocabularyResponse encoder vocabulary
+
+                                    Results.Created(Urls.vocabularyById(response.CollectionId, response.Id), response)
                                 | Error error -> toCreateErrorResponse error
                     })
         )
@@ -134,12 +137,14 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapGet(
             UrlTokens.ById,
-            Func<int, int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId id user dataSource cancellationToken ->
+            Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -152,7 +157,7 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok detail -> Results.Ok(toVocabularyDetailResponse detail)
+                                | Ok detail -> Results.Ok(toVocabularyDetailResponse encoder detail)
                                 | Error error -> toGetByIdErrorResponse error
                     })
         )
@@ -165,12 +170,14 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPut(
             UrlTokens.ById,
-            Func<int, int, UpdateVocabularyRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId id request user dataSource cancellationToken ->
+            Func<string, string, UpdateVocabularyRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -186,7 +193,7 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
 
                             return
                                 match result with
-                                | Ok vocabulary -> Results.Ok(toVocabularyResponse vocabulary)
+                                | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
                                 | Error error -> toUpdateErrorResponse error
                     })
         )
@@ -200,12 +207,14 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapDelete(
             UrlTokens.ById,
-            Func<int, int, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId id user dataSource cancellationToken ->
+            Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
+                        | None, _, _ -> return Results.Unauthorized()
+                        | _, None, _
+                        | _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some id ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -231,12 +240,20 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.ById + "/move",
-            Func<int, int, MoveVocabularyRequest, ClaimsPrincipal, NpgsqlDataSource, CancellationToken, _>
-                (fun collectionId id request user dataSource cancellationToken ->
+            Func<string, string, MoveVocabularyRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
+                (fun collectionId id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
+                        match
+                            getUserId user,
+                            encoder.Decode(collectionId),
+                            encoder.Decode(id),
+                            encoder.Decode(request.CollectionId)
+                        with
+                        | None, _, _, _ -> return Results.Unauthorized()
+                        | _, None, _, _
+                        | _, _, None, _
+                        | _, _, _, None -> return Results.NotFound()
+                        | Some userId, Some collectionId, Some id, Some targetCollectionId ->
                             let env =
                                 TransactionalEnv(dataSource, cancellationToken)
 
@@ -246,12 +263,12 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
                                     { UserId = UserId userId
                                       CollectionId = CollectionId collectionId
                                       VocabularyId = VocabularyId id
-                                      TargetCollectionId = CollectionId request.CollectionId
+                                      TargetCollectionId = CollectionId targetCollectionId
                                       UpdatedAt = DateTimeOffset.UtcNow }
 
                             return
                                 match result with
-                                | Ok vocabulary -> Results.Ok(toVocabularyResponse vocabulary)
+                                | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
                                 | Error error -> toMoveErrorResponse error
                     })
         )

--- a/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Handlers.fs
@@ -140,25 +140,26 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                getById
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId id }
+                                let! result =
+                                    getById
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId id }
 
-                            return
-                                match result with
-                                | Ok detail -> Results.Ok(toVocabularyDetailResponse encoder detail)
-                                | Error error -> toGetByIdErrorResponse error
+                                return
+                                    match result with
+                                    | Ok detail -> Results.Ok(toVocabularyDetailResponse encoder detail)
+                                    | Error error -> toGetByIdErrorResponse error
                     })
         )
         .Produces<VocabularyDetailResponse>(StatusCodes.Status200OK)
@@ -173,28 +174,29 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, UpdateVocabularyRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId id request user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                update
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId id
-                                      Name = request.Name
-                                      Description = request.Description
-                                      UpdatedAt = DateTimeOffset.UtcNow }
+                                let! result =
+                                    update
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId id
+                                          Name = request.Name
+                                          Description = request.Description
+                                          UpdatedAt = DateTimeOffset.UtcNow }
 
-                            return
-                                match result with
-                                | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
-                                | Error error -> toUpdateErrorResponse error
+                                return
+                                    match result with
+                                    | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
+                                    | Error error -> toUpdateErrorResponse error
                     })
         )
         .Produces<VocabularyResponse>(StatusCodes.Status200OK)
@@ -210,25 +212,26 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId id user encoder dataSource cancellationToken ->
                     task {
-                        match getUserId user, encoder.Decode(collectionId), encoder.Decode(id) with
-                        | None, _, _ -> return Results.Unauthorized()
-                        | _, None, _
-                        | _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some id ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, id) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, id) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                delete
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId id }
+                                let! result =
+                                    delete
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId id }
 
-                            return
-                                match result with
-                                | Ok() -> Results.NoContent()
-                                | Error error -> toDeleteErrorResponse error
+                                return
+                                    match result with
+                                    | Ok() -> Results.NoContent()
+                                    | Error error -> toDeleteErrorResponse error
                     })
         )
         .Produces(StatusCodes.Status204NoContent)
@@ -243,33 +246,28 @@ let mapVocabulariesEndpoints(group: RouteGroupBuilder) =
             Func<string, string, MoveVocabularyRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId id request user encoder dataSource cancellationToken ->
                     task {
-                        match
-                            getUserId user,
-                            encoder.Decode(collectionId),
-                            encoder.Decode(id),
-                            encoder.Decode(request.CollectionId)
-                        with
-                        | None, _, _, _ -> return Results.Unauthorized()
-                        | _, None, _, _
-                        | _, _, None, _
-                        | _, _, _, None -> return Results.NotFound()
-                        | Some userId, Some collectionId, Some id, Some targetCollectionId ->
-                            let env =
-                                TransactionalEnv(dataSource, cancellationToken)
+                        match getUserId user with
+                        | None -> return Results.Unauthorized()
+                        | Some userId ->
+                            match ResourceIdsHelper.Decode(encoder, collectionId, id, request.CollectionId) with
+                            | None -> return Results.NotFound()
+                            | Some(collectionId, id, targetCollectionId) ->
+                                let env =
+                                    TransactionalEnv(dataSource, cancellationToken)
 
-                            let! result =
-                                move
-                                    env
-                                    { UserId = UserId userId
-                                      CollectionId = CollectionId collectionId
-                                      VocabularyId = VocabularyId id
-                                      TargetCollectionId = CollectionId targetCollectionId
-                                      UpdatedAt = DateTimeOffset.UtcNow }
+                                let! result =
+                                    move
+                                        env
+                                        { UserId = UserId userId
+                                          CollectionId = CollectionId collectionId
+                                          VocabularyId = VocabularyId id
+                                          TargetCollectionId = CollectionId targetCollectionId
+                                          UpdatedAt = DateTimeOffset.UtcNow }
 
-                            return
-                                match result with
-                                | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
-                                | Error error -> toMoveErrorResponse error
+                                return
+                                    match result with
+                                    | Ok vocabulary -> Results.Ok(toVocabularyResponse encoder vocabulary)
+                                    | Error error -> toMoveErrorResponse error
                     })
         )
         .Produces<VocabularyResponse>(StatusCodes.Status200OK)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Mappers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Mappers.fs
@@ -3,18 +3,19 @@ module Wordfolio.Api.Api.Vocabularies.Mappers
 open Wordfolio.Api.Api.Vocabularies.Types
 open Wordfolio.Api.Domain
 open Wordfolio.Api.Domain.Vocabularies
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
-let toVocabularyResponse(vocabulary: Vocabulary) : VocabularyResponse =
-    { Id = VocabularyId.value vocabulary.Id
-      CollectionId = CollectionId.value vocabulary.CollectionId
+let toVocabularyResponse (encoder: IResourceIdEncoder) (vocabulary: Vocabulary) : VocabularyResponse =
+    { Id = encoder.Encode(VocabularyId.value vocabulary.Id)
+      CollectionId = encoder.Encode(CollectionId.value vocabulary.CollectionId)
       Name = vocabulary.Name
       Description = vocabulary.Description
       CreatedAt = vocabulary.CreatedAt
       UpdatedAt = vocabulary.UpdatedAt }
 
-let toVocabularyDetailResponse(detail: VocabularyDetail) : VocabularyDetailResponse =
-    { Id = VocabularyId.value detail.Id
-      CollectionId = CollectionId.value detail.CollectionId
+let toVocabularyDetailResponse (encoder: IResourceIdEncoder) (detail: VocabularyDetail) : VocabularyDetailResponse =
+    { Id = encoder.Encode(VocabularyId.value detail.Id)
+      CollectionId = encoder.Encode(CollectionId.value detail.CollectionId)
       CollectionName = detail.CollectionName
       Name = detail.Name
       Description = detail.Description

--- a/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Types.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Vocabularies/Types.fs
@@ -3,16 +3,16 @@ module Wordfolio.Api.Api.Vocabularies.Types
 open System
 
 type VocabularyResponse =
-    { Id: int
-      CollectionId: int
+    { Id: string
+      CollectionId: string
       Name: string
       Description: string option
       CreatedAt: DateTimeOffset
       UpdatedAt: DateTimeOffset }
 
 type VocabularyDetailResponse =
-    { Id: int
-      CollectionId: int
+    { Id: string
+      CollectionId: string
       CollectionName: string
       Name: string
       Description: string option
@@ -27,4 +27,4 @@ type UpdateVocabularyRequest =
     { Name: string
       Description: string option }
 
-type MoveVocabularyRequest = { CollectionId: int }
+type MoveVocabularyRequest = { CollectionId: string }

--- a/Wordfolio.Api/Wordfolio.Api/Configuration/SqidsEncoder.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Configuration/SqidsEncoder.fs
@@ -1,0 +1,4 @@
+module Wordfolio.Api.Configuration.SqidsEncoder
+
+[<CLIMutable>]
+type SqidsEncoderConfiguration = { Alphabet: string }

--- a/Wordfolio.Api/Wordfolio.Api/Infrastructure/ResourceIdEncoder.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Infrastructure/ResourceIdEncoder.fs
@@ -1,0 +1,28 @@
+module Wordfolio.Api.Infrastructure.ResourceIdEncoder
+
+open Microsoft.Extensions.Options
+open Sqids
+
+open Wordfolio.Api.Configuration.SqidsEncoder
+
+type IResourceIdEncoder =
+    abstract member Encode: int -> string
+    abstract member Decode: string -> int option
+
+type ResourceIdEncoder(options: IOptions<SqidsEncoderConfiguration>) =
+    let sqids =
+        SqidsEncoder(SqidsOptions(Alphabet = options.Value.Alphabet))
+
+    interface IResourceIdEncoder with
+        member _.Encode(id: int) = sqids.Encode(id)
+
+        member _.Decode(encoded: string) =
+            let ids = sqids.Decode(encoded)
+
+            if
+                ids.Count = 1
+                && sqids.Encode(ids.[0]) = encoded
+            then
+                Some ids.[0]
+            else
+                None

--- a/Wordfolio.Api/Wordfolio.Api/Program.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Program.fs
@@ -6,6 +6,7 @@ open Microsoft.Extensions.Hosting
 
 open Wordfolio.Api
 open Wordfolio.Api.Configuration.GroqApi
+open Wordfolio.Api.Configuration.SqidsEncoder
 open Wordfolio.Api.DataAccess
 open Wordfolio.Api.Api.Auth.Handlers
 open Wordfolio.Api.Api.Collections.Handlers
@@ -17,6 +18,7 @@ open Wordfolio.Api.Api.Vocabularies.Handlers
 open Wordfolio.Api.IdentityIntegration
 open Wordfolio.Api.Infrastructure.ChatClient
 open Wordfolio.Api.Infrastructure.GroqChatClient
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 open Wordfolio.ServiceDefaults.Builder
 open Wordfolio.ServiceDefaults.HealthCheck
 open Wordfolio.ServiceDefaults.OpenApi
@@ -69,6 +71,14 @@ let main args =
     builder.AddNpgsqlDataSource("wordfoliodb")
 
     builder.Services.AddOptions<GroqApiConfiguration>().BindConfiguration("GroqApi")
+    |> ignore
+
+    builder.Services
+        .AddOptions<SqidsEncoderConfiguration>()
+        .BindConfiguration("SqidsEncoder")
+    |> ignore
+
+    builder.Services.AddSingleton<IResourceIdEncoder, ResourceIdEncoder>()
     |> ignore
 
     builder.Services.AddSingleton<IChatClient, GroqChatClient>()

--- a/Wordfolio.Api/Wordfolio.Api/Urls.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Urls.fs
@@ -4,13 +4,13 @@ module Wordfolio.Api.Urls
 let Root = "/"
 
 [<Literal>]
-let ById = "/{id:int}"
+let ById = "/{id}"
 
 module Collections =
     [<Literal>]
     let Path = "/collections"
 
-    let collectionById(id: int) = $"{Path}/{id}"
+    let collectionById(encodedId: string) = $"{Path}/{encodedId}"
 
 module CollectionsHierarchy =
     [<Literal>]
@@ -21,39 +21,38 @@ module CollectionsHierarchy =
 
     [<Literal>]
     let VocabulariesByCollectionPath =
-        "/collections/{collectionId:int}/vocabularies"
+        "/collections/{collectionId}/vocabularies"
 
     let collections() = $"{Path}{CollectionsPath}"
 
-    let vocabulariesByCollection(collectionId: int) =
-        $"{collections()}/{collectionId}/vocabularies"
+    let vocabulariesByCollection(encodedCollectionId: string) =
+        $"{collections()}/{encodedCollectionId}/vocabularies"
 
 module Vocabularies =
     [<Literal>]
-    let Path =
-        "/{collectionId:int}/vocabularies"
+    let Path = "/{collectionId}/vocabularies"
 
-    let vocabulariesByCollection(collectionId: int) =
-        $"/collections/{collectionId}/vocabularies"
+    let vocabulariesByCollection(encodedCollectionId: string) =
+        $"/collections/{encodedCollectionId}/vocabularies"
 
-    let vocabularyById(collectionId: int, vocabularyId: int) =
-        $"{vocabulariesByCollection collectionId}/{vocabularyId}"
+    let vocabularyById(encodedCollectionId: string, encodedVocabularyId: string) =
+        $"{vocabulariesByCollection encodedCollectionId}/{encodedVocabularyId}"
 
-    let moveVocabularyById(collectionId: int, vocabularyId: int) =
-        $"{vocabularyById(collectionId, vocabularyId)}/move"
+    let moveVocabularyById(encodedCollectionId: string, encodedVocabularyId: string) =
+        $"{vocabularyById(encodedCollectionId, encodedVocabularyId)}/move"
 
 module Entries =
     [<Literal>]
-    let Path = "/{vocabularyId:int}/entries"
+    let Path = "/{vocabularyId}/entries"
 
-    let entriesByVocabulary(collectionId: int, vocabularyId: int) =
-        $"/collections/{collectionId}/vocabularies/{vocabularyId}/entries"
+    let entriesByVocabulary(encodedCollectionId: string, encodedVocabularyId: string) =
+        $"/collections/{encodedCollectionId}/vocabularies/{encodedVocabularyId}/entries"
 
-    let entryById(collectionId: int, vocabularyId: int, id: int) =
-        $"{entriesByVocabulary(collectionId, vocabularyId)}/{id}"
+    let entryById(encodedCollectionId: string, encodedVocabularyId: string, encodedId: string) =
+        $"{entriesByVocabulary(encodedCollectionId, encodedVocabularyId)}/{encodedId}"
 
-    let moveEntryById(collectionId: int, vocabularyId: int, id: int) =
-        $"{entryById(collectionId, vocabularyId, id)}/move"
+    let moveEntryById(encodedCollectionId: string, encodedVocabularyId: string, encodedId: string) =
+        $"{entryById(encodedCollectionId, encodedVocabularyId, encodedId)}/move"
 
 module Drafts =
     [<Literal>]
@@ -66,8 +65,8 @@ module Drafts =
     let Move = "/move"
 
     let allDrafts() = $"{Path}{All}"
-    let draftById(id: int) = $"{Path}/{id}"
-    let moveDraftById(id: int) = $"{draftById id}{Move}"
+    let draftById(encodedId: string) = $"{Path}/{encodedId}"
+    let moveDraftById(encodedId: string) = $"{draftById encodedId}{Move}"
 
 module Auth =
     [<Literal>]

--- a/Wordfolio.Api/Wordfolio.Api/Urls.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Urls.fs
@@ -10,7 +10,7 @@ module Collections =
     [<Literal>]
     let Path = "/collections"
 
-    let collectionById(encodedId: string) = $"{Path}/{encodedId}"
+    let collectionById(id: string) = $"{Path}/{id}"
 
 module CollectionsHierarchy =
     [<Literal>]
@@ -25,34 +25,34 @@ module CollectionsHierarchy =
 
     let collections() = $"{Path}{CollectionsPath}"
 
-    let vocabulariesByCollection(encodedCollectionId: string) =
-        $"{collections()}/{encodedCollectionId}/vocabularies"
+    let vocabulariesByCollection(collectionId: string) =
+        $"{collections()}/{collectionId}/vocabularies"
 
 module Vocabularies =
     [<Literal>]
     let Path = "/{collectionId}/vocabularies"
 
-    let vocabulariesByCollection(encodedCollectionId: string) =
-        $"/collections/{encodedCollectionId}/vocabularies"
+    let vocabulariesByCollection(collectionId: string) =
+        $"/collections/{collectionId}/vocabularies"
 
-    let vocabularyById(encodedCollectionId: string, encodedVocabularyId: string) =
-        $"{vocabulariesByCollection encodedCollectionId}/{encodedVocabularyId}"
+    let vocabularyById(collectionId: string, vocabularyId: string) =
+        $"{vocabulariesByCollection collectionId}/{vocabularyId}"
 
-    let moveVocabularyById(encodedCollectionId: string, encodedVocabularyId: string) =
-        $"{vocabularyById(encodedCollectionId, encodedVocabularyId)}/move"
+    let moveVocabularyById(collectionId: string, vocabularyId: string) =
+        $"{vocabularyById(collectionId, vocabularyId)}/move"
 
 module Entries =
     [<Literal>]
     let Path = "/{vocabularyId}/entries"
 
-    let entriesByVocabulary(encodedCollectionId: string, encodedVocabularyId: string) =
-        $"/collections/{encodedCollectionId}/vocabularies/{encodedVocabularyId}/entries"
+    let entriesByVocabulary(collectionId: string, vocabularyId: string) =
+        $"/collections/{collectionId}/vocabularies/{vocabularyId}/entries"
 
-    let entryById(encodedCollectionId: string, encodedVocabularyId: string, encodedId: string) =
-        $"{entriesByVocabulary(encodedCollectionId, encodedVocabularyId)}/{encodedId}"
+    let entryById(collectionId: string, vocabularyId: string, id: string) =
+        $"{entriesByVocabulary(collectionId, vocabularyId)}/{id}"
 
-    let moveEntryById(encodedCollectionId: string, encodedVocabularyId: string, encodedId: string) =
-        $"{entryById(encodedCollectionId, encodedVocabularyId, encodedId)}/move"
+    let moveEntryById(collectionId: string, vocabularyId: string, id: string) =
+        $"{entryById(collectionId, vocabularyId, id)}/move"
 
 module Drafts =
     [<Literal>]
@@ -65,8 +65,8 @@ module Drafts =
     let Move = "/move"
 
     let allDrafts() = $"{Path}{All}"
-    let draftById(encodedId: string) = $"{Path}/{encodedId}"
-    let moveDraftById(encodedId: string) = $"{draftById encodedId}{Move}"
+    let draftById(id: string) = $"{Path}/{id}"
+    let moveDraftById(id: string) = $"{draftById id}{Move}"
 
 module Auth =
     [<Literal>]

--- a/Wordfolio.Api/Wordfolio.Api/Wordfolio.Api.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api/Wordfolio.Api.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="Urls.fs" />
     <Compile Include="Configuration\GroqApi.fs" />
+    <Compile Include="Configuration\SqidsEncoder.fs" />
     <Compile Include="IdentityIntegration.fs" />
     <Compile Include="Infrastructure\ResourceIdEncoder.fs" />
     <Compile Include="Infrastructure\IChatClient.fs" />
@@ -68,8 +69,12 @@
     <OpenApiDocumentsDirectory>$(BaseIntermediateOutputPath)</OpenApiDocumentsDirectory>
   </PropertyGroup>
 
-  <Target Name="PublishOpenApiSpec" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
-    <Copy SourceFiles="$(BaseIntermediateOutputPath)$(MSBuildProjectName).json" DestinationFiles="$(MSBuildProjectDirectory)/../../api/openapi.json" Condition="Exists('$(BaseIntermediateOutputPath)$(MSBuildProjectName).json')" />
+  <Target Name="PublishOpenApiSpec" AfterTargets="Build"
+          Condition="'$(DesignTimeBuild)' != 'true'">
+    <Copy
+      SourceFiles="$(BaseIntermediateOutputPath)$(MSBuildProjectName).json"
+      DestinationFiles="$(MSBuildProjectDirectory)/../../api/openapi.json"
+      Condition="Exists('$(BaseIntermediateOutputPath)$(MSBuildProjectName).json')" />
   </Target>
 
 </Project>

--- a/Wordfolio.Api/Wordfolio.Api/Wordfolio.Api.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api/Wordfolio.Api.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Urls.fs" />
     <Compile Include="Configuration\GroqApi.fs" />
     <Compile Include="IdentityIntegration.fs" />
+    <Compile Include="Infrastructure\ResourceIdEncoder.fs" />
     <Compile Include="Infrastructure\IChatClient.fs" />
     <Compile Include="Infrastructure\DelimitedStreamProcessor.fs" />
     <Compile Include="Infrastructure\GroqChatClient.fs" />
@@ -59,6 +60,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sqids" Version="3.2.1" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -66,12 +68,8 @@
     <OpenApiDocumentsDirectory>$(BaseIntermediateOutputPath)</OpenApiDocumentsDirectory>
   </PropertyGroup>
 
-  <Target Name="PublishOpenApiSpec" AfterTargets="Build"
-          Condition="'$(DesignTimeBuild)' != 'true'">
-    <Copy
-      SourceFiles="$(BaseIntermediateOutputPath)$(MSBuildProjectName).json"
-      DestinationFiles="$(MSBuildProjectDirectory)/../../api/openapi.json"
-      Condition="Exists('$(BaseIntermediateOutputPath)$(MSBuildProjectName).json')" />
+  <Target Name="PublishOpenApiSpec" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true'">
+    <Copy SourceFiles="$(BaseIntermediateOutputPath)$(MSBuildProjectName).json" DestinationFiles="$(MSBuildProjectDirectory)/../../api/openapi.json" Condition="Exists('$(BaseIntermediateOutputPath)$(MSBuildProjectName).json')" />
   </Target>
 
 </Project>

--- a/Wordfolio.Api/Wordfolio.Api/appsettings.Development.json
+++ b/Wordfolio.Api/Wordfolio.Api/appsettings.Development.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "SqidsEncoder": {
+    "Alphabet": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  },
   "ConnectionStrings": {
     // A connection string is here to enable use of the `dotnet ef` cmd line tool from the project root.
     // If the configuration value is not present or not well-formed, the app will fail at startup.

--- a/Wordfolio.Api/Wordfolio.Api/appsettings.json
+++ b/Wordfolio.Api/Wordfolio.Api/appsettings.json
@@ -10,5 +10,8 @@
     "ApiKey": "",
     "Model": "openai/gpt-oss-20b",
     "Url": "https://api.groq.com/openai/v1"
+  },
+  "SqidsEncoder": {
+    "Alphabet": ""
   }
 }

--- a/Wordfolio.Frontend/src/features/collections/components/CollectionDetailContent.tsx
+++ b/Wordfolio.Frontend/src/features/collections/components/CollectionDetailContent.tsx
@@ -6,7 +6,7 @@ import type { VocabularyWithEntryCount } from "../../../shared/api/types/collect
 
 interface CollectionDetailContentProps {
     readonly vocabularies: VocabularyWithEntryCount[];
-    readonly onVocabularyClick: (id: number) => void;
+    readonly onVocabularyClick: (id: string) => void;
     readonly onCreateVocabularyClick: () => void;
     readonly sortModel: GridSortModel;
     readonly onSortModelChange: (model: GridSortModel) => void;

--- a/Wordfolio.Frontend/src/features/collections/components/CollectionsContent.tsx
+++ b/Wordfolio.Frontend/src/features/collections/components/CollectionsContent.tsx
@@ -6,7 +6,7 @@ import type { CollectionWithVocabularyCount } from "../../../shared/api/types/co
 
 interface CollectionsContentProps {
     readonly collections: CollectionWithVocabularyCount[];
-    readonly onCollectionClick: (id: number) => void;
+    readonly onCollectionClick: (id: string) => void;
     readonly onCreateClick: () => void;
     readonly sortModel: GridSortModel;
     readonly onSortModelChange: (model: GridSortModel) => void;

--- a/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
@@ -122,7 +122,7 @@ export const CollectionDetailPage = () => {
     };
 
     const handleVocabularyClick = useCallback(
-        (vocabId: number) => {
+        (vocabId: string) => {
             void navigate(vocabularyDetailPath(collectionId, vocabId));
         },
         [navigate, collectionId]

--- a/Wordfolio.Frontend/src/features/collections/pages/CollectionsPage.tsx
+++ b/Wordfolio.Frontend/src/features/collections/pages/CollectionsPage.tsx
@@ -71,7 +71,7 @@ export const CollectionsPage = () => {
     } = useCollectionsQuery();
 
     const handleCollectionClick = useCallback(
-        (id: number) => {
+        (id: string) => {
             void navigate(collectionDetailPath(id));
         },
         [navigate]

--- a/Wordfolio.Frontend/src/features/collections/routes.ts
+++ b/Wordfolio.Frontend/src/features/collections/routes.ts
@@ -16,14 +16,14 @@ export function collectionsPath() {
     return { to: "/collections" as const };
 }
 
-export function collectionDetailPath(collectionId: number) {
+export function collectionDetailPath(collectionId: string) {
     return {
         to: "/collections/$collectionId" as const,
         params: { collectionId },
     };
 }
 
-export function collectionEditPath(collectionId: number) {
+export function collectionEditPath(collectionId: string) {
     return {
         to: "/collections/$collectionId/edit" as const,
         params: { collectionId },

--- a/Wordfolio.Frontend/src/features/collections/schemas/collectionSchemas.ts
+++ b/Wordfolio.Frontend/src/features/collections/schemas/collectionSchemas.ts
@@ -13,7 +13,7 @@ export const collectionSchema = z.object({
 });
 
 export const collectionIdRouteParamsSchema = z.object({
-    collectionId: z.coerce.number().int().positive(),
+    collectionId: z.string().min(1),
 });
 
 export type CollectionFormInput = z.input<typeof collectionSchema>;

--- a/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
+++ b/Wordfolio.Frontend/src/features/design-system/pages/DesignSystemPage.tsx
@@ -69,40 +69,40 @@ const stubDraftCount = 3;
 
 const stubCollectionData = [
     {
-        id: 1,
+        id: "1",
         name: "English Vocabulary",
         entryCount: 4,
         children: [
-            { id: 6, name: "Common Words", entryCount: 156 },
-            { id: 7, name: "Academic Terms", entryCount: 89 },
-            { id: 8, name: "Idioms & Phrases", entryCount: 42 },
+            { id: "6", name: "Common Words", entryCount: 156 },
+            { id: "7", name: "Academic Terms", entryCount: 89 },
+            { id: "8", name: "Idioms & Phrases", entryCount: 42 },
         ],
     },
     {
-        id: 2,
+        id: "2",
         name: "Spanish Basics",
         entryCount: 3,
         children: [
-            { id: 9, name: "Greetings", entryCount: 24 },
-            { id: 10, name: "Travel Phrases", entryCount: 37 },
+            { id: "9", name: "Greetings", entryCount: 24 },
+            { id: "10", name: "Travel Phrases", entryCount: 37 },
         ],
     },
-    { id: 3, name: "Academic Writing", entryCount: 0 },
+    { id: "3", name: "Academic Writing", entryCount: 0 },
     {
-        id: 4,
+        id: "4",
         name: "Japanese",
         entryCount: 2,
         children: [
-            { id: 11, name: "Hiragana", entryCount: 46 },
-            { id: 12, name: "Katakana", entryCount: 46 },
-            { id: 13, name: "JLPT N5 Kanji", entryCount: 103 },
+            { id: "11", name: "Hiragana", entryCount: 46 },
+            { id: "12", name: "Katakana", entryCount: 46 },
+            { id: "13", name: "JLPT N5 Kanji", entryCount: 103 },
         ],
     },
     {
-        id: 5,
+        id: "5",
         name: "French Literature",
         entryCount: 1,
-        children: [{ id: 14, name: "Romantic Era", entryCount: 28 }],
+        children: [{ id: "14", name: "Romantic Era", entryCount: 28 }],
     },
 ];
 
@@ -223,19 +223,19 @@ const ColorSwatch = ({ hex, role }: { hex: string; role: string }) => (
 );
 
 export const DesignSystemPage = () => {
-    const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set([1]));
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(["1"]));
     const [selectedCollectionId, setSelectedCollectionId] = useState<
-        number | null
+        string | null
     >(null);
     const [selectedVocabularyId, setSelectedVocabularyId] = useState<
-        number | null
-    >(6);
+        string | null
+    >("6");
     const [gridSortModel, setGridSortModel] = useState<GridSortModel>([
         { field: "updated", sort: "desc" },
     ]);
     const [gridFilter, setGridFilter] = useState("");
 
-    const toggleCollection = (id: number) => {
+    const toggleCollection = (id: string) => {
         setExpandedIds((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);
@@ -244,12 +244,12 @@ export const DesignSystemPage = () => {
         });
     };
 
-    const selectCollection = (id: number) => {
+    const selectCollection = (id: string) => {
         setSelectedCollectionId(id);
         setSelectedVocabularyId(null);
     };
 
-    const selectVocabulary = (childId: number) => {
+    const selectVocabulary = (childId: string) => {
         setSelectedVocabularyId(childId);
         setSelectedCollectionId(null);
     };

--- a/Wordfolio.Frontend/src/features/drafts/components/DraftsContent.tsx
+++ b/Wordfolio.Frontend/src/features/drafts/components/DraftsContent.tsx
@@ -6,7 +6,7 @@ import { Entry } from "../../../shared/api/types/entries";
 
 interface DraftsContentProps {
     readonly entries: Entry[];
-    readonly onEntryClick: (id: number) => void;
+    readonly onEntryClick: (id: string) => void;
     readonly onAddDraftClick: () => void;
     readonly sortModel: GridSortModel;
     readonly onSortModelChange: (model: GridSortModel) => void;

--- a/Wordfolio.Frontend/src/features/drafts/pages/DraftsPage.tsx
+++ b/Wordfolio.Frontend/src/features/drafts/pages/DraftsPage.tsx
@@ -67,7 +67,7 @@ export const DraftsPage = () => {
     const { data, isLoading, isError, refetch } = useDraftsQuery();
 
     const handleEntryClick = useCallback(
-        (entryId: number) => {
+        (entryId: string) => {
             void navigate(draftsEntryDetailPath(entryId));
         },
         [navigate]

--- a/Wordfolio.Frontend/src/features/drafts/routes.ts
+++ b/Wordfolio.Frontend/src/features/drafts/routes.ts
@@ -22,14 +22,14 @@ export function draftsCreatePath() {
     return { to: "/drafts/new" as const };
 }
 
-export function draftsEntryDetailPath(entryId: number) {
+export function draftsEntryDetailPath(entryId: string) {
     return {
         to: "/drafts/entries/$entryId" as const,
         params: { entryId },
     };
 }
 
-export function draftsEntryEditPath(entryId: number) {
+export function draftsEntryEditPath(entryId: string) {
     return {
         to: "/drafts/entries/$entryId/edit" as const,
         params: { entryId },

--- a/Wordfolio.Frontend/src/features/drafts/schemas/draftSchemas.ts
+++ b/Wordfolio.Frontend/src/features/drafts/schemas/draftSchemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const draftEntryRouteParamsSchema = z.object({
-    entryId: z.coerce.number().int().positive(),
+    entryId: z.string().min(1),
 });
 
 export const draftsListSearchParamsSchema = z.object({

--- a/Wordfolio.Frontend/src/features/entries/routes.ts
+++ b/Wordfolio.Frontend/src/features/entries/routes.ts
@@ -11,9 +11,9 @@ export const entryEditRouteApi = getRouteApi(entryRouteIds.edit);
 export const entryCreateRouteApi = getRouteApi(entryRouteIds.create);
 
 export function entryDetailPath(
-    collectionId: number,
-    vocabularyId: number,
-    entryId: number
+    collectionId: string,
+    vocabularyId: string,
+    entryId: string
 ) {
     return {
         to: "/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId" as const,
@@ -26,9 +26,9 @@ export function entryDetailPath(
 }
 
 export function entryEditPath(
-    collectionId: number,
-    vocabularyId: number,
-    entryId: number
+    collectionId: string,
+    vocabularyId: string,
+    entryId: string
 ) {
     return {
         to: "/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit" as const,
@@ -40,7 +40,7 @@ export function entryEditPath(
     };
 }
 
-export function entryCreatePath(collectionId: number, vocabularyId: number) {
+export function entryCreatePath(collectionId: string, vocabularyId: string) {
     return {
         to: "/collections/$collectionId/vocabularies/$vocabularyId/entries/new" as const,
         params: {

--- a/Wordfolio.Frontend/src/features/entries/schemas/entrySchemas.ts
+++ b/Wordfolio.Frontend/src/features/entries/schemas/entrySchemas.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const entryCreateRouteParamsSchema = z.object({
-    collectionId: z.coerce.number().int().positive(),
-    vocabularyId: z.coerce.number().int().positive(),
+    collectionId: z.string().min(1),
+    vocabularyId: z.string().min(1),
 });
 
 export const entryRouteParamsSchema = z.object({
-    collectionId: z.coerce.number().int().positive(),
-    vocabularyId: z.coerce.number().int().positive(),
-    entryId: z.coerce.number().int().positive(),
+    collectionId: z.string().min(1),
+    vocabularyId: z.string().min(1),
+    entryId: z.string().min(1),
 });

--- a/Wordfolio.Frontend/src/features/vocabularies/components/MoveVocabularyDialog.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/MoveVocabularyDialog.tsx
@@ -62,7 +62,7 @@ export const MoveVocabularyDialog = ({
     const handleTargetChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
             const value = event.target.value;
-            setSelectedCollectionId(value || undefined);
+            setSelectedCollectionId(value);
         },
         []
     );

--- a/Wordfolio.Frontend/src/features/vocabularies/components/MoveVocabularyDialog.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/MoveVocabularyDialog.tsx
@@ -16,12 +16,12 @@ import { ResponsiveDialog } from "../../../shared/components/ResponsiveDialog";
 import { useCollectionsHierarchyQuery } from "../../../shared/api/queries/collections";
 
 export interface MoveVocabularySelectionResult {
-    readonly collectionId: number;
+    readonly collectionId: string;
 }
 
 interface MoveVocabularyDialogProps {
     readonly isOpen: boolean;
-    readonly currentCollectionId: number;
+    readonly currentCollectionId: string;
     readonly onCancel: () => void;
     readonly onConfirm: (value: MoveVocabularySelectionResult) => void;
 }
@@ -33,7 +33,7 @@ export const MoveVocabularyDialog = ({
     onConfirm,
 }: MoveVocabularyDialogProps) => {
     const [selectedCollectionId, setSelectedCollectionId] = useState<
-        number | undefined
+        string | undefined
     >(undefined);
 
     const {
@@ -61,8 +61,8 @@ export const MoveVocabularyDialog = ({
 
     const handleTargetChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>) => {
-            const value = Number(event.target.value);
-            setSelectedCollectionId(Number.isNaN(value) ? undefined : value);
+            const value = event.target.value;
+            setSelectedCollectionId(value || undefined);
         },
         []
     );

--- a/Wordfolio.Frontend/src/features/vocabularies/components/VocabularyDetailContent.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/VocabularyDetailContent.tsx
@@ -6,7 +6,7 @@ import { Entry } from "../../../shared/api/types/entries";
 
 interface VocabularyDetailContentProps {
     readonly entries: Entry[];
-    readonly onEntryClick: (id: number) => void;
+    readonly onEntryClick: (id: string) => void;
     readonly onAddWordClick: () => void;
     readonly sortModel: GridSortModel;
     readonly onSortModelChange: (model: GridSortModel) => void;

--- a/Wordfolio.Frontend/src/features/vocabularies/hooks/useMoveVocabularyDialog.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/hooks/useMoveVocabularyDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from "../components/MoveVocabularyDialog";
 
 export interface RaiseMoveVocabularyDialogOptions {
-    readonly currentCollectionId: number;
+    readonly currentCollectionId: string;
 }
 
 interface MoveVocabularyDialogState {

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
@@ -178,7 +178,7 @@ export const VocabularyDetailPage = () => {
     ]);
 
     const handleEntryClick = useCallback(
-        (entryId: number) => {
+        (entryId: string) => {
             void navigate(entryDetailPath(collectionId, vocabularyId, entryId));
         },
         [navigate, collectionId, vocabularyId]

--- a/Wordfolio.Frontend/src/features/vocabularies/routes.ts
+++ b/Wordfolio.Frontend/src/features/vocabularies/routes.ts
@@ -11,8 +11,8 @@ export const vocabularyEditRouteApi = getRouteApi(vocabularyRouteIds.edit);
 export const vocabularyCreateRouteApi = getRouteApi(vocabularyRouteIds.create);
 
 export function vocabularyDetailPath(
-    collectionId: number,
-    vocabularyId: number
+    collectionId: string,
+    vocabularyId: string
 ) {
     return {
         to: "/collections/$collectionId/vocabularies/$vocabularyId" as const,
@@ -23,7 +23,7 @@ export function vocabularyDetailPath(
     };
 }
 
-export function vocabularyEditPath(collectionId: number, vocabularyId: number) {
+export function vocabularyEditPath(collectionId: string, vocabularyId: string) {
     return {
         to: "/collections/$collectionId/vocabularies/$vocabularyId/edit" as const,
         params: {
@@ -33,7 +33,7 @@ export function vocabularyEditPath(collectionId: number, vocabularyId: number) {
     };
 }
 
-export function vocabularyCreatePath(collectionId: number) {
+export function vocabularyCreatePath(collectionId: string) {
     return {
         to: "/collections/$collectionId/vocabularies/new" as const,
         params: { collectionId },

--- a/Wordfolio.Frontend/src/features/vocabularies/schemas/vocabularySchemas.ts
+++ b/Wordfolio.Frontend/src/features/vocabularies/schemas/vocabularySchemas.ts
@@ -13,12 +13,12 @@ export const vocabularySchema = z.object({
 });
 
 export const vocabularyCreateRouteParamsSchema = z.object({
-    collectionId: z.coerce.number().int().positive(),
+    collectionId: z.string().min(1),
 });
 
 export const vocabularyRouteParamsSchema = z.object({
-    collectionId: z.coerce.number().int().positive(),
-    vocabularyId: z.coerce.number().int().positive(),
+    collectionId: z.string().min(1),
+    vocabularyId: z.string().min(1),
 });
 
 export type VocabularyFormInput = z.input<typeof vocabularySchema>;

--- a/Wordfolio.Frontend/src/shared/api/generated/schema.d.ts
+++ b/Wordfolio.Frontend/src/shared/api/generated/schema.d.ts
@@ -130,7 +130,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -173,7 +173,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -228,7 +228,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -281,7 +281,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
+                    collectionId: string;
                 };
                 cookie?: never;
             };
@@ -318,7 +318,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
+                    collectionId: string;
                 };
                 cookie?: never;
             };
@@ -378,8 +378,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    id: number;
+                    collectionId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -422,8 +422,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    id: number;
+                    collectionId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -478,8 +478,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    id: number;
+                    collectionId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -534,8 +534,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    id: number;
+                    collectionId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -588,8 +588,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
+                    collectionId: string;
+                    vocabularyId: string;
                 };
                 cookie?: never;
             };
@@ -626,8 +626,8 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
+                    collectionId: string;
+                    vocabularyId: string;
                 };
                 cookie?: never;
             };
@@ -694,9 +694,9 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
-                    id: number;
+                    collectionId: string;
+                    vocabularyId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -732,9 +732,9 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
-                    id: number;
+                    collectionId: string;
+                    vocabularyId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -782,9 +782,9 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
-                    id: number;
+                    collectionId: string;
+                    vocabularyId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -832,9 +832,9 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
-                    vocabularyId: number;
-                    id: number;
+                    collectionId: string;
+                    vocabularyId: string;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -971,7 +971,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    collectionId: number;
+                    collectionId: string;
                 };
                 cookie?: never;
             };
@@ -1124,7 +1124,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -1160,7 +1160,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -1208,7 +1208,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -1256,7 +1256,7 @@ export interface paths {
                 query?: never;
                 header?: never;
                 path: {
-                    id: number;
+                    id: string;
                 };
                 cookie?: never;
             };
@@ -1810,8 +1810,7 @@ export interface components {
             environment: string;
         };
         CollectionResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             name: string;
             description?: null | string;
             /** Format: date-time */
@@ -1824,8 +1823,7 @@ export interface components {
             defaultVocabulary?: null | components["schemas"]["VocabularyWithEntryCountResponse"];
         };
         CollectionWithVocabulariesResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             name: string;
             description?: null | string;
             /** Format: date-time */
@@ -1835,8 +1833,7 @@ export interface components {
             vocabularies: components["schemas"]["VocabularyWithEntryCountResponse"][];
         };
         CollectionWithVocabularyCountResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             name: string;
             description?: null | string;
             /** Format: date-time */
@@ -1872,8 +1869,7 @@ export interface components {
             examples: components["schemas"]["ExampleRequest"][];
         };
         DefinitionResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             definitionText: string;
             source: components["schemas"]["DefinitionSource"];
             /** Format: int32 */
@@ -1887,10 +1883,8 @@ export interface components {
             entries: components["schemas"]["EntryResponse"][];
         };
         EntryResponse: {
-            /** Format: int32 */
-            id: number;
-            /** Format: int32 */
-            vocabularyId: number;
+            id: string;
+            vocabularyId: string;
             entryText: string;
             /** Format: date-time */
             createdAt: string;
@@ -1904,8 +1898,7 @@ export interface components {
             source: components["schemas"]["ExampleSource"];
         };
         ExampleResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             exampleText: string;
             source: components["schemas"]["ExampleSource"];
         };
@@ -1941,15 +1934,13 @@ export interface components {
             twoFactorRecoveryCode?: null | string;
         };
         MoveDraftRequest: {
-            /** Format: int32 */
-            vocabularyId: number;
+            vocabularyId: string;
         };
         MoveEntryRequest: {
-            vocabularyId?: null | number;
+            vocabularyId?: null | string;
         };
         MoveVocabularyRequest: {
-            /** Format: int32 */
-            collectionId: number;
+            collectionId: string;
         };
         PasswordRequirementsResponse: {
             /** Format: int32 */
@@ -1982,8 +1973,7 @@ export interface components {
             examples: components["schemas"]["ExampleRequest"][];
         };
         TranslationResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             translationText: string;
             source: components["schemas"]["TranslationSource"];
             /** Format: int32 */
@@ -2021,10 +2011,8 @@ export interface components {
             description?: null | string;
         };
         VocabularyDetailResponse: {
-            /** Format: int32 */
-            id: number;
-            /** Format: int32 */
-            collectionId: number;
+            id: string;
+            collectionId: string;
             collectionName: string;
             name: string;
             description?: null | string;
@@ -2034,10 +2022,8 @@ export interface components {
             updatedAt: string;
         };
         VocabularyResponse: {
-            /** Format: int32 */
-            id: number;
-            /** Format: int32 */
-            collectionId: number;
+            id: string;
+            collectionId: string;
             name: string;
             description?: null | string;
             /** Format: date-time */
@@ -2046,8 +2032,7 @@ export interface components {
             updatedAt: string;
         };
         VocabularyWithEntryCountResponse: {
-            /** Format: int32 */
-            id: number;
+            id: string;
             name: string;
             description?: null | string;
             /** Format: date-time */

--- a/Wordfolio.Frontend/src/shared/api/mutations/collections.ts
+++ b/Wordfolio.Frontend/src/shared/api/mutations/collections.ts
@@ -47,7 +47,7 @@ interface UseUpdateCollectionMutationOptions {
 }
 
 export function useUpdateCollectionMutation(
-    id: number,
+    id: string,
     options?: UseUpdateCollectionMutationOptions
 ) {
     const queryClient = useQueryClient();
@@ -86,7 +86,7 @@ export function useDeleteCollectionMutation(
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: async (id: number) => {
+        mutationFn: async (id: string) => {
             const { error } = await client.DELETE("/collections/{id}", {
                 params: { path: { id } },
             });

--- a/Wordfolio.Frontend/src/shared/api/mutations/drafts.ts
+++ b/Wordfolio.Frontend/src/shared/api/mutations/drafts.ts
@@ -65,7 +65,7 @@ export function useCreateDraftMutation(
 }
 
 interface UpdateDraftEntryParams {
-    readonly entryId: number;
+    readonly entryId: string;
     readonly data: CreateEntryData;
 }
 
@@ -97,7 +97,7 @@ export function useUpdateDraftEntryMutation(
 }
 
 interface DeleteDraftEntryParams {
-    readonly entryId: number;
+    readonly entryId: string;
 }
 
 interface UseDeleteDraftEntryMutationOptions {
@@ -126,8 +126,8 @@ export function useDeleteDraftEntryMutation(
 }
 
 interface MoveDraftEntryParams {
-    readonly entryId: number;
-    readonly targetVocabularyId: number;
+    readonly entryId: string;
+    readonly targetVocabularyId: string;
 }
 
 interface UseMoveDraftEntryMutationOptions {

--- a/Wordfolio.Frontend/src/shared/api/mutations/entries.ts
+++ b/Wordfolio.Frontend/src/shared/api/mutations/entries.ts
@@ -16,8 +16,8 @@ import { isDuplicateEntryError } from "../types/entries";
 import type { components } from "../generated/schema";
 
 interface CreateEntryParams {
-    readonly collectionId: number;
-    readonly vocabularyId: number;
+    readonly collectionId: string;
+    readonly vocabularyId: string;
     readonly input: CreateEntryData;
     readonly allowDuplicate?: boolean;
 }
@@ -76,9 +76,9 @@ export function useCreateEntryMutation(
 }
 
 interface UpdateEntryParams {
-    readonly collectionId: number;
-    readonly vocabularyId: number;
-    readonly entryId: number;
+    readonly collectionId: string;
+    readonly vocabularyId: string;
+    readonly entryId: string;
     readonly data: CreateEntryData;
 }
 
@@ -120,9 +120,9 @@ export function useUpdateEntryMutation(
 }
 
 interface DeleteEntryParams {
-    readonly collectionId: number;
-    readonly vocabularyId: number;
-    readonly entryId: number;
+    readonly collectionId: string;
+    readonly vocabularyId: string;
+    readonly entryId: string;
 }
 
 interface UseDeleteEntryMutationOptions {
@@ -160,10 +160,10 @@ export function useDeleteEntryMutation(
 }
 
 interface MoveEntryParams {
-    readonly collectionId: number;
-    readonly entryId: number;
-    readonly sourceVocabularyId: number;
-    readonly targetVocabularyId: number | undefined;
+    readonly collectionId: string;
+    readonly entryId: string;
+    readonly sourceVocabularyId: string;
+    readonly targetVocabularyId: string | undefined;
 }
 
 interface UseMoveEntryMutationOptions {

--- a/Wordfolio.Frontend/src/shared/api/mutations/vocabularies.ts
+++ b/Wordfolio.Frontend/src/shared/api/mutations/vocabularies.ts
@@ -10,7 +10,7 @@ interface VocabularyInput {
 }
 
 interface CreateVocabularyMutationVariables {
-    collectionId: number;
+    collectionId: string;
     data: VocabularyInput;
 }
 
@@ -51,8 +51,8 @@ export const useCreateVocabularyMutation = (
 };
 
 interface UpdateVocabularyMutationVariables {
-    collectionId: number;
-    vocabularyId: number;
+    collectionId: string;
+    vocabularyId: string;
     data: VocabularyInput;
 }
 
@@ -96,8 +96,8 @@ export const useUpdateVocabularyMutation = (
 };
 
 interface DeleteVocabularyMutationVariables {
-    collectionId: number;
-    vocabularyId: number;
+    collectionId: string;
+    vocabularyId: string;
 }
 
 interface UseDeleteVocabularyMutationOptions {
@@ -134,9 +134,9 @@ export const useDeleteVocabularyMutation = (
 };
 
 interface MoveVocabularyParams {
-    readonly sourceCollectionId: number;
-    readonly vocabularyId: number;
-    readonly targetCollectionId: number;
+    readonly sourceCollectionId: string;
+    readonly vocabularyId: string;
+    readonly targetCollectionId: string;
 }
 
 interface UseMoveVocabularyMutationOptions {

--- a/Wordfolio.Frontend/src/shared/api/queries/collections.ts
+++ b/Wordfolio.Frontend/src/shared/api/queries/collections.ts
@@ -30,7 +30,7 @@ export const useCollectionsQuery = (
     });
 
 export const useCollectionQuery = (
-    id: number,
+    id: string,
     options?: Partial<UseQueryOptions<Collection>>
 ) =>
     useQuery({
@@ -59,7 +59,7 @@ export const useCollectionsHierarchyQuery = (
     });
 
 export const useCollectionVocabulariesQuery = (
-    collectionId: number,
+    collectionId: string,
     options?: Partial<UseQueryOptions<VocabularyWithEntryCount[]>>
 ) =>
     useQuery({

--- a/Wordfolio.Frontend/src/shared/api/queries/drafts.ts
+++ b/Wordfolio.Frontend/src/shared/api/queries/drafts.ts
@@ -25,7 +25,7 @@ export const useDraftsQuery = (
     });
 
 export const useDraftEntryQuery = (
-    entryId: number,
+    entryId: string,
     options?: Partial<UseQueryOptions<Entry>>
 ) =>
     useQuery({

--- a/Wordfolio.Frontend/src/shared/api/queries/entries.ts
+++ b/Wordfolio.Frontend/src/shared/api/queries/entries.ts
@@ -5,8 +5,8 @@ import { mapEntry } from "../mappers/entries";
 import type { Entry } from "../types/entries";
 
 export const useVocabularyEntriesQuery = (
-    collectionId: number,
-    vocabularyId: number,
+    collectionId: string,
+    vocabularyId: string,
     options?: Partial<UseQueryOptions<Entry[]>>
 ) =>
     useQuery({
@@ -23,9 +23,9 @@ export const useVocabularyEntriesQuery = (
     });
 
 export const useEntryQuery = (
-    collectionId: number,
-    vocabularyId: number,
-    entryId: number,
+    collectionId: string,
+    vocabularyId: string,
+    entryId: string,
     options?: Partial<UseQueryOptions<Entry>>
 ) =>
     useQuery({

--- a/Wordfolio.Frontend/src/shared/api/queries/vocabularies.ts
+++ b/Wordfolio.Frontend/src/shared/api/queries/vocabularies.ts
@@ -11,8 +11,8 @@ import type {
 } from "../types/vocabularies";
 
 export const useVocabularyDetailQuery = (
-    collectionId: number,
-    vocabularyId: number,
+    collectionId: string,
+    vocabularyId: string,
     options?: Partial<UseQueryOptions<VocabularyDetail>>
 ) =>
     useQuery({
@@ -29,7 +29,7 @@ export const useVocabularyDetailQuery = (
     });
 
 export const useVocabularyCollectionQuery = (
-    collectionId: number,
+    collectionId: string,
     options?: Partial<UseQueryOptions<VocabularyCollectionContext>>
 ) =>
     useQuery({

--- a/Wordfolio.Frontend/src/shared/api/types/collections.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/collections.ts
@@ -1,5 +1,5 @@
 export interface Collection {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
@@ -7,7 +7,7 @@ export interface Collection {
 }
 
 export interface CollectionWithVocabularyCount {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly description: string | null;
     readonly vocabularyCount: number;
@@ -16,7 +16,7 @@ export interface CollectionWithVocabularyCount {
 }
 
 export interface VocabularyWithEntryCount {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly description: string | null;
     readonly entryCount: number;
@@ -25,7 +25,7 @@ export interface VocabularyWithEntryCount {
 }
 
 export interface CollectionWithVocabularies {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;

--- a/Wordfolio.Frontend/src/shared/api/types/drafts.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/drafts.ts
@@ -1,7 +1,7 @@
 import type { Entry } from "./entries";
 
 export interface DraftsVocabulary {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;

--- a/Wordfolio.Frontend/src/shared/api/types/entries.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/entries.ts
@@ -16,13 +16,13 @@ export enum ExampleSource {
 }
 
 export interface Example {
-    readonly id: number;
+    readonly id: string;
     readonly exampleText: string;
     readonly source: ExampleSource;
 }
 
 export interface Definition {
-    readonly id: number;
+    readonly id: string;
     readonly definitionText: string;
     readonly source: DefinitionSource;
     readonly displayOrder: number;
@@ -30,7 +30,7 @@ export interface Definition {
 }
 
 export interface Translation {
-    readonly id: number;
+    readonly id: string;
     readonly translationText: string;
     readonly source: TranslationSource;
     readonly displayOrder: number;
@@ -38,8 +38,8 @@ export interface Translation {
 }
 
 export interface Entry {
-    readonly id: number;
-    readonly vocabularyId: number;
+    readonly id: string;
+    readonly vocabularyId: string;
     readonly entryText: string;
     readonly createdAt: Date;
     readonly updatedAt: Date;

--- a/Wordfolio.Frontend/src/shared/api/types/vocabularies.ts
+++ b/Wordfolio.Frontend/src/shared/api/types/vocabularies.ts
@@ -1,6 +1,6 @@
 export interface Vocabulary {
-    readonly id: number;
-    readonly collectionId: number;
+    readonly id: string;
+    readonly collectionId: string;
     readonly name: string;
     readonly description: string | null;
     readonly createdAt: Date;
@@ -8,8 +8,8 @@ export interface Vocabulary {
 }
 
 export interface VocabularyDetail {
-    readonly id: number;
-    readonly collectionId: number;
+    readonly id: string;
+    readonly collectionId: string;
     readonly collectionName: string;
     readonly name: string;
     readonly description: string | null;
@@ -18,6 +18,6 @@ export interface VocabularyDetail {
 }
 
 export interface VocabularyCollectionContext {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
 }

--- a/Wordfolio.Frontend/src/shared/components/ContentDataGrid.tsx
+++ b/Wordfolio.Frontend/src/shared/components/ContentDataGrid.tsx
@@ -46,7 +46,7 @@ interface ContentDataGridProps<R extends GridValidRowModel> {
     readonly rows: R[];
     readonly desktopColumns: GridColDef<R>[];
     readonly mobileColumns: GridColDef<R>[];
-    readonly onRowClick: (id: number) => void;
+    readonly onRowClick: (id: string) => void;
     readonly actionLabel: string;
     readonly onAction: () => void;
     readonly searchPlaceholder?: string;

--- a/Wordfolio.Frontend/src/shared/components/MoveEntryDialog.tsx
+++ b/Wordfolio.Frontend/src/shared/components/MoveEntryDialog.tsx
@@ -14,14 +14,14 @@ import { ResponsiveDialog } from "./ResponsiveDialog";
 import { useCollectionsHierarchyQuery } from "../api/queries/collections";
 
 export interface MoveEntrySelectionResult {
-    readonly vocabularyId: number | undefined;
+    readonly vocabularyId: string | undefined;
     readonly isDefault: boolean;
-    readonly collectionId: number | null;
+    readonly collectionId: string | null;
 }
 
 interface MoveEntryDialogProps {
     readonly isOpen: boolean;
-    readonly currentVocabularyId: number;
+    readonly currentVocabularyId: string;
     readonly onCancel: () => void;
     readonly onConfirm: (value: MoveEntrySelectionResult) => void;
 }
@@ -33,7 +33,7 @@ export const MoveEntryDialog = ({
     onConfirm,
 }: MoveEntryDialogProps) => {
     const [selectedVocabularyId, setSelectedVocabularyId] = useState<
-        number | undefined
+        string | undefined
     >(undefined);
 
     const {
@@ -78,7 +78,7 @@ export const MoveEntryDialog = ({
     }, [currentVocabularyId, hierarchy]);
 
     const resolveSelection = useCallback(
-        (vocabularyId: number): MoveEntrySelectionResult | undefined => {
+        (vocabularyId: string): MoveEntrySelectionResult | undefined => {
             if (!hierarchy) {
                 return undefined;
             }
@@ -109,7 +109,7 @@ export const MoveEntryDialog = ({
         [hierarchy]
     );
 
-    const handleTargetChange = useCallback((value: number) => {
+    const handleTargetChange = useCallback((value: string) => {
         setSelectedVocabularyId(value);
     }, []);
 

--- a/Wordfolio.Frontend/src/shared/components/VocabularySelector.tsx
+++ b/Wordfolio.Frontend/src/shared/components/VocabularySelector.tsx
@@ -9,14 +9,14 @@ import {
 import type { CollectionsHierarchy } from "../api/types/collections";
 import styles from "./VocabularySelector.module.scss";
 
-export const draftsValue = 0;
+export const draftsValue = "drafts";
 
 interface VocabularySelectorProps {
     readonly hierarchy: CollectionsHierarchy | undefined;
-    readonly value: number | undefined;
+    readonly value: string | undefined;
     readonly label: string;
-    readonly onChange: (value: number) => void;
-    readonly excludeVocabularyId?: number;
+    readonly onChange: (value: string) => void;
+    readonly excludeVocabularyId?: string;
     readonly fullWidth?: boolean;
     readonly className?: string;
 }
@@ -25,7 +25,7 @@ const DRAFTS_LABEL = "Drafts — organize later";
 
 const buildGroupedItems = (
     hierarchy: CollectionsHierarchy,
-    excludeVocabularyId: number | undefined
+    excludeVocabularyId: string | undefined
 ) => {
     const showDrafts =
         excludeVocabularyId === undefined ||
@@ -83,8 +83,8 @@ export const VocabularySelector = ({
     );
 
     const handleChange = useCallback(
-        (event: SelectChangeEvent<number | string>) => {
-            onChange(Number(event.target.value));
+        (event: SelectChangeEvent<string>) => {
+            onChange(event.target.value);
         },
         [onChange]
     );

--- a/Wordfolio.Frontend/src/shared/components/entries/EntryLookupForm.tsx
+++ b/Wordfolio.Frontend/src/shared/components/entries/EntryLookupForm.tsx
@@ -14,12 +14,12 @@ import styles from "./EntryLookupForm.module.scss";
 type EntryLookupFormVariant = "modal" | "page";
 
 export interface VocabularyContext {
-    readonly collectionId: number;
-    readonly vocabularyId: number;
+    readonly collectionId: string;
+    readonly vocabularyId: string;
 }
 
 interface EntryLookupFormProps {
-    readonly vocabularyId?: number;
+    readonly vocabularyId?: string;
     readonly showVocabularySelector?: boolean;
     readonly isSaving: boolean;
     readonly onSave: (
@@ -42,7 +42,7 @@ export const EntryLookupForm = ({
     autoFocus = false,
     variant = "modal",
 }: EntryLookupFormProps) => {
-    const [selectedVocabularyId, setSelectedVocabularyId] = useState<number>(
+    const [selectedVocabularyId, setSelectedVocabularyId] = useState<string>(
         vocabularyId ?? draftsValue
     );
 

--- a/Wordfolio.Frontend/src/shared/components/entries/WordEntrySheet.tsx
+++ b/Wordfolio.Frontend/src/shared/components/entries/WordEntrySheet.tsx
@@ -15,7 +15,7 @@ import styles from "./WordEntrySheet.module.scss";
 
 interface WordEntrySheetProps {
     readonly open: boolean;
-    readonly initialVocabularyId?: number;
+    readonly initialVocabularyId?: string;
     readonly isSaving: boolean;
     readonly onClose: () => void;
     readonly onSave: (

--- a/Wordfolio.Frontend/src/shared/components/layouts/AppSidebar.tsx
+++ b/Wordfolio.Frontend/src/shared/components/layouts/AppSidebar.tsx
@@ -24,20 +24,20 @@ import styles from "./AppSidebar.module.scss";
 import { WordfolioBrand } from "./WordfolioBrand";
 
 export interface NavCollection {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly entryCount: number;
     readonly active?: boolean;
     readonly expanded?: boolean;
-    readonly activeChildId?: number;
+    readonly activeChildId?: string;
     readonly children?: {
-        readonly id: number;
+        readonly id: string;
         readonly name: string;
         readonly entryCount: number;
     }[];
     readonly onClick?: () => void;
     readonly onExpand?: () => void;
-    readonly onChildClick?: (id: number) => void;
+    readonly onChildClick?: (id: string) => void;
 }
 
 export interface NavUser {

--- a/Wordfolio.Frontend/src/shared/components/layouts/AuthenticatedLayout.tsx
+++ b/Wordfolio.Frontend/src/shared/components/layouts/AuthenticatedLayout.tsx
@@ -54,19 +54,15 @@ export const AuthenticatedLayout = () => {
         refetch: refetchUserInfo,
     } = useUserInfoQuery();
 
-    const activeCollectionId = params.collectionId
-        ? Number(params.collectionId)
-        : undefined;
-    const activeVocabularyId = params.vocabularyId
-        ? Number(params.vocabularyId)
-        : undefined;
+    const activeCollectionId = params.collectionId ?? undefined;
+    const activeVocabularyId = params.vocabularyId ?? undefined;
 
-    const [expandedCollections, setExpandedCollections] = useState<Set<number>>(
+    const [expandedCollections, setExpandedCollections] = useState<Set<string>>(
         () => new Set(activeCollectionId ? [activeCollectionId] : [])
     );
     const pendingRequestRef = useRef<PendingEntry | null>(null);
 
-    const toggleCollection = (id: number) => {
+    const toggleCollection = (id: string) => {
         setExpandedCollections((prev) => {
             const next = new Set(prev);
             if (next.has(id)) next.delete(id);

--- a/Wordfolio.Frontend/src/shared/hooks/useMoveEntryDialog.tsx
+++ b/Wordfolio.Frontend/src/shared/hooks/useMoveEntryDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from "../components/MoveEntryDialog";
 
 export interface RaiseMoveEntryDialogOptions {
-    readonly currentVocabularyId: number;
+    readonly currentVocabularyId: string;
 }
 
 interface MoveEntryDialogState {

--- a/Wordfolio.Frontend/src/shared/stores/uiStore.ts
+++ b/Wordfolio.Frontend/src/shared/stores/uiStore.ts
@@ -2,15 +2,15 @@ import { create } from "zustand";
 
 interface UiState {
     readonly isWordEntryOpen: boolean;
-    readonly selectedVocabularyId: number | null;
-    openWordEntry: (vocabularyId?: number) => void;
+    readonly selectedVocabularyId: string | null;
+    openWordEntry: (vocabularyId?: string) => void;
     closeWordEntry: () => void;
 }
 
 export const useUiStore = create<UiState>()((set) => ({
     isWordEntryOpen: false,
     selectedVocabularyId: null,
-    openWordEntry: (vocabularyId?: number) =>
+    openWordEntry: (vocabularyId?: string) =>
         set({
             isWordEntryOpen: true,
             selectedVocabularyId: vocabularyId ?? null,

--- a/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/MoveEntryDialog.test.tsx
@@ -16,14 +16,14 @@ const createHierarchy = (
 ): CollectionsHierarchy => ({
     collections: [
         {
-            id: 1,
+            id: "1",
             name: "English Collection",
             description: null,
             createdAt: new Date(),
             updatedAt: new Date(),
             vocabularies: [
                 {
-                    id: 10,
+                    id: "10",
                     name: "Idioms",
                     description: null,
                     entryCount: 5,
@@ -34,7 +34,7 @@ const createHierarchy = (
         },
     ],
     defaultVocabulary: {
-        id: 99,
+        id: "99",
         name: "Drafts",
         description: null,
         entryCount: 3,
@@ -44,7 +44,7 @@ const createHierarchy = (
     ...overrides,
 });
 
-const renderMoveEntryDialog = (currentVocabularyId: number) =>
+const renderMoveEntryDialog = (currentVocabularyId: string) =>
     render(
         <MoveEntryDialog
             isOpen={true}
@@ -67,7 +67,7 @@ describe("MoveEntryDialog", () => {
             refetch: vi.fn(),
         });
 
-        renderMoveEntryDialog(10);
+        renderMoveEntryDialog("10");
 
         expect(screen.getByRole("combobox")).toHaveTextContent(
             "Drafts — organize later"
@@ -79,7 +79,7 @@ describe("MoveEntryDialog", () => {
         useCollectionsHierarchyQueryMock.mockReturnValue({
             data: createHierarchy({
                 defaultVocabulary: {
-                    id: 10,
+                    id: "10",
                     name: "Drafts",
                     description: null,
                     entryCount: 3,
@@ -92,7 +92,7 @@ describe("MoveEntryDialog", () => {
             refetch: vi.fn(),
         });
 
-        renderMoveEntryDialog(10);
+        renderMoveEntryDialog("10");
 
         expect(screen.getByRole("combobox")).not.toHaveTextContent(
             "Drafts — organize later"
@@ -113,7 +113,7 @@ describe("MoveEntryDialog", () => {
         render(
             <MoveEntryDialog
                 isOpen={true}
-                currentVocabularyId={10}
+                currentVocabularyId="10"
                 onCancel={vi.fn()}
                 onConfirm={onConfirm}
             />
@@ -127,6 +127,6 @@ describe("MoveEntryDialog", () => {
             collectionId: null,
         });
         expect(useCollectionsHierarchyQueryMock).toHaveBeenCalled();
-        expect(draftsValue).toBe(0);
+        expect(draftsValue).toBe("drafts");
     });
 });

--- a/Wordfolio.Frontend/tests/shared/components/VocabularySelector.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/VocabularySelector.test.tsx
@@ -12,14 +12,14 @@ const createHierarchy = (
 ): CollectionsHierarchy => ({
     collections: [
         {
-            id: 1,
+            id: "1",
             name: "English Collection",
             description: null,
             createdAt: new Date(),
             updatedAt: new Date(),
             vocabularies: [
                 {
-                    id: 10,
+                    id: "10",
                     name: "Idioms",
                     description: null,
                     entryCount: 5,
@@ -27,7 +27,7 @@ const createHierarchy = (
                     updatedAt: new Date(),
                 },
                 {
-                    id: 11,
+                    id: "11",
                     name: "Phrasal Verbs",
                     description: null,
                     entryCount: 3,
@@ -37,14 +37,14 @@ const createHierarchy = (
             ],
         },
         {
-            id: 2,
+            id: "2",
             name: "Spanish Collection",
             description: null,
             createdAt: new Date(),
             updatedAt: new Date(),
             vocabularies: [
                 {
-                    id: 20,
+                    id: "20",
                     name: "Basic Words",
                     description: null,
                     entryCount: 10,
@@ -63,9 +63,9 @@ const renderVocabularySelector = (
 ) => {
     const defaultProps = {
         hierarchy: createHierarchy(),
-        value: undefined as number | undefined,
+        value: undefined as string | undefined,
         label: "Target vocabulary",
-        onChange: vi.fn() as (value: number) => void,
+        onChange: vi.fn() as (value: string) => void,
         ...props,
     };
 
@@ -123,7 +123,7 @@ describe("VocabularySelector", () => {
         renderVocabularySelector({
             hierarchy: createHierarchy({
                 defaultVocabulary: {
-                    id: 99,
+                    id: "99",
                     name: "Default Vocab",
                     description: null,
                     entryCount: 0,
@@ -143,7 +143,7 @@ describe("VocabularySelector", () => {
 
     it("should exclude specified vocabulary id", async () => {
         const user = userEvent.setup();
-        renderVocabularySelector({ excludeVocabularyId: 10 });
+        renderVocabularySelector({ excludeVocabularyId: "10" });
 
         await user.click(screen.getByRole("combobox"));
 
@@ -155,7 +155,7 @@ describe("VocabularySelector", () => {
 
     it("should exclude entire collection when all its vocabularies are excluded", async () => {
         const user = userEvent.setup();
-        renderVocabularySelector({ excludeVocabularyId: 20 });
+        renderVocabularySelector({ excludeVocabularyId: "20" });
 
         await user.click(screen.getByRole("combobox"));
 
@@ -173,7 +173,7 @@ describe("VocabularySelector", () => {
         renderVocabularySelector({
             hierarchy: createHierarchy({
                 defaultVocabulary: {
-                    id: 99,
+                    id: "99",
                     name: "Default Vocab",
                     description: null,
                     entryCount: 0,
@@ -181,7 +181,7 @@ describe("VocabularySelector", () => {
                     updatedAt: new Date(),
                 },
             }),
-            excludeVocabularyId: 99,
+            excludeVocabularyId: "99",
         });
 
         await user.click(screen.getByRole("combobox"));
@@ -202,14 +202,14 @@ describe("VocabularySelector", () => {
         const listbox = screen.getByRole("listbox");
         await user.click(within(listbox).getByText("Phrasal Verbs"));
 
-        expect(onChange).toHaveBeenCalledWith(11);
+        expect(onChange).toHaveBeenCalledWith("11");
     });
 
     it("should call onChange with draftsValue when the Drafts option is selected", async () => {
         const user = userEvent.setup();
         const onChange = vi.fn();
         renderVocabularySelector({
-            value: 11,
+            value: "11",
             onChange,
         });
 

--- a/Wordfolio.Frontend/tests/shared/components/layouts/AppSidebar.test.tsx
+++ b/Wordfolio.Frontend/tests/shared/components/layouts/AppSidebar.test.tsx
@@ -56,7 +56,7 @@ describe("AppSidebar", () => {
     it("does not render the empty state when collections is non-empty", () => {
         const collections: NavCollection[] = [
             {
-                id: 1,
+                id: "1",
                 name: "My Collection",
                 entryCount: 5,
             },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -98,9 +98,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -139,9 +137,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -192,9 +188,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -228,9 +222,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -269,9 +261,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -321,9 +311,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -331,9 +319,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -372,9 +358,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -382,9 +366,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -435,9 +417,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -445,9 +425,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -481,9 +459,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -491,9 +467,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -540,9 +514,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -550,9 +522,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -591,9 +561,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -601,9 +569,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -656,9 +622,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -666,9 +630,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -676,9 +638,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -714,9 +674,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -724,9 +682,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,9 +690,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -765,9 +719,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -775,9 +727,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -785,9 +735,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -837,9 +785,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -847,9 +793,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -857,9 +801,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -959,9 +901,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1067,9 +1007,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1105,9 +1043,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1155,9 +1091,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1188,9 +1122,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1681,8 +1613,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -1738,8 +1669,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -1777,8 +1707,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -1932,8 +1861,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "definitionText": {
             "type": "string"
@@ -1990,12 +1918,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "vocabularyId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "entryText": {
             "type": "string"
@@ -2046,8 +1972,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "exampleText": {
             "type": "string"
@@ -2191,8 +2116,7 @@
         "type": "object",
         "properties": {
           "vocabularyId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           }
         }
       },
@@ -2202,7 +2126,7 @@
           "vocabularyId": {
             "type": [
               "null",
-              "integer"
+              "string"
             ]
           }
         }
@@ -2214,8 +2138,7 @@
         "type": "object",
         "properties": {
           "collectionId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           }
         }
       },
@@ -2341,8 +2264,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "translationText": {
             "type": "string"
@@ -2498,12 +2420,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "collectionId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "collectionName": {
             "type": "string"
@@ -2538,12 +2458,10 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "collectionId": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -2575,8 +2493,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
-            "format": "int32"
+            "type": "string"
           },
           "name": {
             "type": "string"


### PR DESCRIPTION
Closes #249

## Summary

- encode internal integer IDs into short opaque strings at the API boundary using Sqids
- decode obfuscated IDs back to integers on incoming requests
- keep the internal database schema, domain layer, and data access layer unchanged
- update frontend routing, API types, and UI flows to treat resource IDs as opaque strings

## Notes

- API-exposed IDs and route params are now strings in OpenAPI and the generated frontend client
- backend and frontend CI validations passed before PR creation