### PR TITLE
Add vocabulary practice flashcards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,6 @@ FodyWeavers.xsd
 
 # opencode settings
 opencode.json
+
+# Playwright MCP artifacts
+.playwright-mcp/

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
@@ -1,0 +1,39 @@
+.card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    padding: 32px;
+    border-radius: 12px;
+    cursor: pointer;
+    user-select: none;
+    transition: box-shadow 0.2s ease;
+
+    &:hover {
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.24);
+    }
+
+    &:focus-visible {
+        outline: 2px solid;
+        outline-offset: 2px;
+    }
+}
+
+.front {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    text-align: center;
+}
+
+.back {
+    width: 100%;
+    overflow-y: auto;
+    max-height: 60vh;
+}
+
+.hint {
+    margin-top: 8px;
+}

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
@@ -1,39 +1,19 @@
-.card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 300px;
-    padding: 32px;
-    border-radius: 12px;
-    cursor: pointer;
-    user-select: none;
-    transition: box-shadow 0.2s ease;
+.flashCard {
+    .front {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+        text-align: center;
 
-    &:hover {
-        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.24);
+        .hint {
+            margin-top: 8px;
+        }
     }
 
-    &:focus-visible {
-        outline: 2px solid;
-        outline-offset: 2px;
+    .back {
+        width: 100%;
+        overflow-y: auto;
+        max-height: 60vh;
     }
-}
-
-.front {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 16px;
-    text-align: center;
-}
-
-.back {
-    width: 100%;
-    overflow-y: auto;
-    max-height: 60vh;
-}
-
-.hint {
-    margin-top: 8px;
 }

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.module.scss
@@ -1,4 +1,13 @@
 .flashCard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    padding: 32px;
+    cursor: pointer;
+    user-select: none;
+
     .front {
         display: flex;
         flex-direction: column;

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
@@ -1,0 +1,50 @@
+import { Box, Paper, Typography } from "@mui/material";
+
+import type { Entry } from "../../../shared/api/types/entries";
+import { EntryDetailContent } from "../../../shared/components/entries/EntryDetailContent";
+
+import styles from "./FlashCard.module.scss";
+
+interface FlashCardProps {
+    readonly entry: Entry;
+    readonly isFlipped: boolean;
+    readonly onFlip: () => void;
+}
+
+export const FlashCard = ({ entry, isFlipped, onFlip }: FlashCardProps) => {
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onFlip();
+        }
+    };
+
+    return (
+        <Paper
+            className={styles.card}
+            onClick={onFlip}
+            onKeyDown={handleKeyDown}
+            role="button"
+            tabIndex={0}
+            aria-label={isFlipped ? "Card back" : "Card front — tap to reveal"}
+            elevation={2}
+        >
+            {isFlipped ? (
+                <Box className={styles.back}>
+                    <EntryDetailContent entry={entry} />
+                </Box>
+            ) : (
+                <Box className={styles.front}>
+                    <Typography variant="h2">{entry.entryText}</Typography>
+                    <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        className={styles.hint}
+                    >
+                        Tap to reveal
+                    </Typography>
+                </Box>
+            )}
+        </Paper>
+    );
+};

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
@@ -21,13 +21,30 @@ export const FlashCard = ({ entry, isFlipped, onFlip }: FlashCardProps) => {
 
     return (
         <Paper
-            className={styles.card}
+            className={styles.flashCard}
             onClick={onFlip}
             onKeyDown={handleKeyDown}
             role="button"
             tabIndex={0}
             aria-label={isFlipped ? "Card back" : "Card front — tap to reveal"}
             elevation={2}
+            sx={(theme) => ({
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: 300,
+                padding: 4,
+                cursor: "pointer",
+                userSelect: "none",
+                "&:hover": {
+                    boxShadow: theme.shadows[4],
+                },
+                "&:focus-visible": {
+                    outline: `2px solid ${theme.palette.primary.main}`,
+                    outlineOffset: 2,
+                },
+            })}
         >
             {isFlipped ? (
                 <Box className={styles.back}>

--- a/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/components/FlashCard.tsx
@@ -29,14 +29,6 @@ export const FlashCard = ({ entry, isFlipped, onFlip }: FlashCardProps) => {
             aria-label={isFlipped ? "Card back" : "Card front — tap to reveal"}
             elevation={2}
             sx={(theme) => ({
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                minHeight: 300,
-                padding: 4,
-                cursor: "pointer",
-                userSelect: "none",
                 "&:hover": {
                     boxShadow: theme.shadows[4],
                 },

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.module.scss
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.module.scss
@@ -1,0 +1,61 @@
+.page {
+    display: flex;
+    flex-direction: column;
+    min-height: 70vh;
+    gap: 24px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.headerTitle {
+    flex: 1;
+}
+
+.headerMeta {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+}
+
+.progress {
+    color: var(--mui-palette-text-secondary);
+    white-space: nowrap;
+}
+
+.cardArea {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.ratingRow {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.completionArea {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    text-align: center;
+}
+
+.completionActions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: center;
+}

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.module.scss
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.module.scss
@@ -1,61 +1,37 @@
-.page {
+.practicePage {
     display: flex;
     flex-direction: column;
     min-height: 70vh;
     gap: 24px;
-}
 
-.header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    flex-wrap: wrap;
-}
+    .cardArea {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
 
-.headerTitle {
-    flex: 1;
-}
+    .ratingRow {
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
 
-.headerMeta {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-top: 4px;
-}
+    .completionArea {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 24px;
+        text-align: center;
 
-.progress {
-    color: var(--mui-palette-text-secondary);
-    white-space: nowrap;
-}
-
-.cardArea {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.ratingRow {
-    display: flex;
-    gap: 12px;
-    justify-content: center;
-    flex-wrap: wrap;
-}
-
-.completionArea {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 24px;
-    text-align: center;
-}
-
-.completionActions {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    justify-content: center;
+        .completionActions {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+    }
 }

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.tsx
@@ -15,6 +15,7 @@ import { ContentSkeleton } from "../../../shared/components/ContentSkeleton";
 import { RetryOnError } from "../../../shared/components/RetryOnError";
 import { EmptyState } from "../../../shared/components/EmptyState";
 import { PageContainer } from "../../../shared/components/PageContainer";
+import { PageHeader } from "../../../shared/components/PageHeader";
 import { TopBarBreadcrumbs } from "../../../shared/components/layouts/TopBarBreadcrumbs";
 
 import styles from "./PracticePage.module.scss";
@@ -73,149 +74,147 @@ export const PracticePage = () => {
         { label: "Practice" },
     ];
 
-    if (isLoading) {
-        return (
-            <PageContainer>
-                <TopBarBreadcrumbs items={breadcrumbItems} />
-                <ContentSkeleton variant="detail" />
-            </PageContainer>
-        );
-    }
+    const renderContent = () => {
+        if (isLoading) {
+            return <ContentSkeleton variant="detail" />;
+        }
 
-    if (isError) {
-        const handleRetry = () => {
-            if (isVocabError) void refetchVocab();
-            if (isEntriesError) void refetchEntries();
-        };
+        if (isError || !vocabulary) {
+            const handleRetry = () => {
+                if (isVocabError) void refetchVocab();
+                if (isEntriesError) void refetchEntries();
+            };
 
-        return (
-            <PageContainer>
-                <TopBarBreadcrumbs items={breadcrumbItems} />
+            return (
                 <RetryOnError
                     title="Failed to Load Vocabulary"
                     description="Something went wrong while loading the practice session. Please try again."
                     onRetry={handleRetry}
                 />
-            </PageContainer>
-        );
-    }
+            );
+        }
 
-    if (!entries || entries.length === 0) {
-        return (
-            <PageContainer>
-                <TopBarBreadcrumbs items={breadcrumbItems} />
-                <Box className={styles.page}>
-                    <EmptyState
-                        icon={
-                            <SchoolIcon
-                                sx={{ fontSize: 32, color: "primary.main" }}
-                            />
-                        }
-                        title="No entries to practice"
-                        description="Add entries to this vocabulary before starting a practice session."
+        if (!entries || entries.length === 0) {
+            return (
+                <>
+                    <PageHeader
+                        title={vocabulary.name}
+                        description="Practice session"
                     />
-                </Box>
-            </PageContainer>
-        );
-    }
-
-    const currentCard = queue[currentIndex];
-
-    if (isComplete || !currentCard) {
-        return (
-            <PageContainer>
-                <TopBarBreadcrumbs items={breadcrumbItems} />
-                <Box className={styles.page}>
-                    <Box className={styles.completionArea}>
-                        <SchoolIcon
-                            sx={{ fontSize: 64, color: "primary.main" }}
+                    <Box className={styles.practicePage}>
+                        <EmptyState
+                            icon={
+                                <SchoolIcon
+                                    sx={{ fontSize: 32, color: "primary.main" }}
+                                />
+                            }
+                            title="No entries to practice"
+                            description="Add entries to this vocabulary before starting a practice session."
                         />
-                        <Typography variant="h2">Session Complete!</Typography>
-                        <Typography variant="body1" color="text.secondary">
-                            You reviewed all cards in{" "}
-                            <strong>
-                                {vocabulary?.name ?? "this vocabulary"}
-                            </strong>
-                            .
-                        </Typography>
-                        <Box className={styles.completionActions}>
-                            <Button
-                                variant="contained"
-                                onClick={handlePracticeAgain}
-                            >
-                                Practice Again
-                            </Button>
+                    </Box>
+                </>
+            );
+        }
+
+        const currentCard = queue[currentIndex];
+
+        if (isComplete || !currentCard) {
+            return (
+                <>
+                    <PageHeader
+                        title={vocabulary.name}
+                        description="Practice session complete"
+                    />
+                    <Box className={styles.practicePage}>
+                        <Box className={styles.completionArea}>
+                            <SchoolIcon
+                                sx={{ fontSize: 64, color: "primary.main" }}
+                            />
+                            <Typography variant="h2">
+                                Session Complete!
+                            </Typography>
+                            <Typography variant="body1" color="text.secondary">
+                                You reviewed all cards in{" "}
+                                <strong>{vocabulary.name}</strong>.
+                            </Typography>
+                            <Box className={styles.completionActions}>
+                                <Button
+                                    variant="contained"
+                                    onClick={handlePracticeAgain}
+                                >
+                                    Practice Again
+                                </Button>
+                            </Box>
                         </Box>
                     </Box>
-                </Box>
-            </PageContainer>
-        );
-    }
+                </>
+            );
+        }
 
-    const progress = `${currentIndex + 1} / ${queue.length}`;
+        const progress = `${currentIndex + 1} / ${queue.length}`;
+
+        return (
+            <>
+                <PageHeader
+                    title={vocabulary.name}
+                    description={
+                        currentCard.pass === 2
+                            ? "Practice session - Pass 2"
+                            : "Practice session"
+                    }
+                    actions={
+                        <Typography
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{ whiteSpace: "nowrap" }}
+                        >
+                            {progress}
+                        </Typography>
+                    }
+                />
+                <Box className={styles.practicePage}>
+                    <Box className={styles.cardArea}>
+                        <FlashCard
+                            entry={currentCard.entry}
+                            isFlipped={isFlipped}
+                            onFlip={flip}
+                        />
+
+                        {isFlipped && (
+                            <Box className={styles.ratingRow}>
+                                <Button
+                                    variant="contained"
+                                    color="success"
+                                    onClick={() => rate("easy")}
+                                >
+                                    Easy
+                                </Button>
+                                <Button
+                                    variant="contained"
+                                    color="warning"
+                                    onClick={() => rate("hard")}
+                                >
+                                    Hard
+                                </Button>
+                                <Button
+                                    variant="contained"
+                                    color="error"
+                                    onClick={() => rate("needsWork")}
+                                >
+                                    Needs Work
+                                </Button>
+                            </Box>
+                        )}
+                    </Box>
+                </Box>
+            </>
+        );
+    };
 
     return (
         <PageContainer>
             <TopBarBreadcrumbs items={breadcrumbItems} />
-            <Box className={styles.page}>
-                <Box className={styles.header}>
-                    <Box className={styles.headerTitle}>
-                        <Typography variant="h4">
-                            {vocabulary?.name ?? "Practice"}
-                        </Typography>
-                        <Box className={styles.headerMeta}>
-                            <Typography variant="body2" color="text.secondary">
-                                Practice session
-                            </Typography>
-                            {currentCard.pass === 2 && (
-                                <Typography
-                                    variant="body2"
-                                    color="text.secondary"
-                                >
-                                    Pass 2
-                                </Typography>
-                            )}
-                        </Box>
-                    </Box>
-                    <Typography variant="body2" className={styles.progress}>
-                        {progress}
-                    </Typography>
-                </Box>
-
-                <Box className={styles.cardArea}>
-                    <FlashCard
-                        entry={currentCard.entry}
-                        isFlipped={isFlipped}
-                        onFlip={flip}
-                    />
-
-                    {isFlipped && (
-                        <Box className={styles.ratingRow}>
-                            <Button
-                                variant="contained"
-                                color="success"
-                                onClick={() => rate("easy")}
-                            >
-                                Easy
-                            </Button>
-                            <Button
-                                variant="contained"
-                                color="warning"
-                                onClick={() => rate("hard")}
-                            >
-                                Hard
-                            </Button>
-                            <Button
-                                variant="contained"
-                                color="error"
-                                onClick={() => rate("needsWork")}
-                            >
-                                Needs Work
-                            </Button>
-                        </Box>
-                    )}
-                </Box>
-            </Box>
+            {renderContent()}
         </PageContainer>
     );
 };

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/PracticePage.tsx
@@ -1,0 +1,221 @@
+import { useEffect } from "react";
+import { Box, Button, Typography } from "@mui/material";
+import SchoolIcon from "@mui/icons-material/School";
+
+import { practiceRouteApi, vocabularyDetailPath } from "../routes";
+import { usePracticeStore } from "../stores/practiceStore";
+import {
+    collectionsPath,
+    collectionDetailPath,
+} from "../../collections/routes";
+import { useVocabularyEntriesQuery } from "../../../shared/api/queries/entries";
+import { useVocabularyDetailQuery } from "../../../shared/api/queries/vocabularies";
+import { FlashCard } from "../components/FlashCard";
+import { ContentSkeleton } from "../../../shared/components/ContentSkeleton";
+import { RetryOnError } from "../../../shared/components/RetryOnError";
+import { EmptyState } from "../../../shared/components/EmptyState";
+import { PageContainer } from "../../../shared/components/PageContainer";
+import { TopBarBreadcrumbs } from "../../../shared/components/layouts/TopBarBreadcrumbs";
+
+import styles from "./PracticePage.module.scss";
+
+export const PracticePage = () => {
+    const { collectionId, vocabularyId } = practiceRouteApi.useParams();
+
+    const {
+        data: vocabulary,
+        isLoading: isVocabLoading,
+        isError: isVocabError,
+        refetch: refetchVocab,
+    } = useVocabularyDetailQuery(collectionId, vocabularyId);
+
+    const {
+        data: entries,
+        isLoading: isEntriesLoading,
+        isError: isEntriesError,
+        refetch: refetchEntries,
+    } = useVocabularyEntriesQuery(collectionId, vocabularyId);
+
+    const {
+        queue,
+        currentIndex,
+        isFlipped,
+        isComplete,
+        initSession,
+        flip,
+        rate,
+    } = usePracticeStore();
+
+    useEffect(() => {
+        if (entries) {
+            initSession(entries);
+        }
+    }, [entries, initSession]);
+
+    const handlePracticeAgain = () => {
+        if (entries) {
+            initSession(entries);
+        }
+    };
+
+    const isLoading = isVocabLoading || isEntriesLoading;
+    const isError = isVocabError || isEntriesError;
+    const breadcrumbItems = [
+        { label: "Collections", ...collectionsPath() },
+        {
+            label: vocabulary?.collectionName ?? "...",
+            ...collectionDetailPath(collectionId),
+        },
+        {
+            label: vocabulary?.name ?? "Vocabulary",
+            ...vocabularyDetailPath(collectionId, vocabularyId),
+        },
+        { label: "Practice" },
+    ];
+
+    if (isLoading) {
+        return (
+            <PageContainer>
+                <TopBarBreadcrumbs items={breadcrumbItems} />
+                <ContentSkeleton variant="detail" />
+            </PageContainer>
+        );
+    }
+
+    if (isError) {
+        const handleRetry = () => {
+            if (isVocabError) void refetchVocab();
+            if (isEntriesError) void refetchEntries();
+        };
+
+        return (
+            <PageContainer>
+                <TopBarBreadcrumbs items={breadcrumbItems} />
+                <RetryOnError
+                    title="Failed to Load Vocabulary"
+                    description="Something went wrong while loading the practice session. Please try again."
+                    onRetry={handleRetry}
+                />
+            </PageContainer>
+        );
+    }
+
+    if (!entries || entries.length === 0) {
+        return (
+            <PageContainer>
+                <TopBarBreadcrumbs items={breadcrumbItems} />
+                <Box className={styles.page}>
+                    <EmptyState
+                        icon={
+                            <SchoolIcon
+                                sx={{ fontSize: 32, color: "primary.main" }}
+                            />
+                        }
+                        title="No entries to practice"
+                        description="Add entries to this vocabulary before starting a practice session."
+                    />
+                </Box>
+            </PageContainer>
+        );
+    }
+
+    const currentCard = queue[currentIndex];
+
+    if (isComplete || !currentCard) {
+        return (
+            <PageContainer>
+                <TopBarBreadcrumbs items={breadcrumbItems} />
+                <Box className={styles.page}>
+                    <Box className={styles.completionArea}>
+                        <SchoolIcon
+                            sx={{ fontSize: 64, color: "primary.main" }}
+                        />
+                        <Typography variant="h2">Session Complete!</Typography>
+                        <Typography variant="body1" color="text.secondary">
+                            You reviewed all cards in{" "}
+                            <strong>
+                                {vocabulary?.name ?? "this vocabulary"}
+                            </strong>
+                            .
+                        </Typography>
+                        <Box className={styles.completionActions}>
+                            <Button
+                                variant="contained"
+                                onClick={handlePracticeAgain}
+                            >
+                                Practice Again
+                            </Button>
+                        </Box>
+                    </Box>
+                </Box>
+            </PageContainer>
+        );
+    }
+
+    const progress = `${currentIndex + 1} / ${queue.length}`;
+
+    return (
+        <PageContainer>
+            <TopBarBreadcrumbs items={breadcrumbItems} />
+            <Box className={styles.page}>
+                <Box className={styles.header}>
+                    <Box className={styles.headerTitle}>
+                        <Typography variant="h4">
+                            {vocabulary?.name ?? "Practice"}
+                        </Typography>
+                        <Box className={styles.headerMeta}>
+                            <Typography variant="body2" color="text.secondary">
+                                Practice session
+                            </Typography>
+                            {currentCard.pass === 2 && (
+                                <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                >
+                                    Pass 2
+                                </Typography>
+                            )}
+                        </Box>
+                    </Box>
+                    <Typography variant="body2" className={styles.progress}>
+                        {progress}
+                    </Typography>
+                </Box>
+
+                <Box className={styles.cardArea}>
+                    <FlashCard
+                        entry={currentCard.entry}
+                        isFlipped={isFlipped}
+                        onFlip={flip}
+                    />
+
+                    {isFlipped && (
+                        <Box className={styles.ratingRow}>
+                            <Button
+                                variant="contained"
+                                color="success"
+                                onClick={() => rate("easy")}
+                            >
+                                Easy
+                            </Button>
+                            <Button
+                                variant="contained"
+                                color="warning"
+                                onClick={() => rate("hard")}
+                            >
+                                Hard
+                            </Button>
+                            <Button
+                                variant="contained"
+                                color="error"
+                                onClick={() => rate("needsWork")}
+                            >
+                                Needs Work
+                            </Button>
+                        </Box>
+                    )}
+                </Box>
+            </Box>
+        </PageContainer>
+    );
+};

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
@@ -5,6 +5,7 @@ import {
     vocabularyDetailPath,
     vocabularyDetailRouteApi,
     vocabularyEditPath,
+    vocabularyPracticePath,
 } from "../routes";
 import type { EntrySortField } from "../schemas/vocabularySchemas";
 import {
@@ -134,6 +135,10 @@ export const VocabularyDetailPage = () => {
         void navigate(vocabularyEditPath(collectionId, vocabularyId));
     }, [navigate, collectionId, vocabularyId]);
 
+    const handlePracticeClick = useCallback(() => {
+        void navigate(vocabularyPracticePath(collectionId, vocabularyId));
+    }, [navigate, collectionId, vocabularyId]);
+
     const handleMoveClick = useCallback(async () => {
         const selection = await raiseMoveVocabularyDialogAsync({
             currentCollectionId: collectionId,
@@ -244,6 +249,11 @@ export const VocabularyDetailPage = () => {
                 actions={
                     <PageHeaderActions
                         actions={[
+                            {
+                                label: "Practice",
+                                onClick: handlePracticeClick,
+                                disabled: isLoading || !entries?.length,
+                            },
                             {
                                 label: "Move",
                                 onClick: handleMoveClick,

--- a/Wordfolio.Frontend/src/features/vocabularies/routes.ts
+++ b/Wordfolio.Frontend/src/features/vocabularies/routes.ts
@@ -4,11 +4,14 @@ export const vocabularyRouteIds = {
     detail: "/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/",
     edit: "/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit",
     create: "/_authenticated/collections/$collectionId/vocabularies/new",
+    practice:
+        "/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice",
 } as const;
 
 export const vocabularyDetailRouteApi = getRouteApi(vocabularyRouteIds.detail);
 export const vocabularyEditRouteApi = getRouteApi(vocabularyRouteIds.edit);
 export const vocabularyCreateRouteApi = getRouteApi(vocabularyRouteIds.create);
+export const practiceRouteApi = getRouteApi(vocabularyRouteIds.practice);
 
 export function vocabularyDetailPath(
     collectionId: string,
@@ -37,5 +40,18 @@ export function vocabularyCreatePath(collectionId: string) {
     return {
         to: "/collections/$collectionId/vocabularies/new" as const,
         params: { collectionId },
+    };
+}
+
+export function vocabularyPracticePath(
+    collectionId: string,
+    vocabularyId: string
+) {
+    return {
+        to: "/collections/$collectionId/vocabularies/$vocabularyId/practice" as const,
+        params: {
+            collectionId,
+            vocabularyId,
+        },
     };
 }

--- a/Wordfolio.Frontend/src/features/vocabularies/stores/practiceStore.ts
+++ b/Wordfolio.Frontend/src/features/vocabularies/stores/practiceStore.ts
@@ -1,0 +1,74 @@
+import { create } from "zustand";
+
+import type { Entry } from "../../../shared/api/types/entries";
+
+export type PracticeRating = "easy" | "hard" | "needsWork";
+
+export interface PracticeCard {
+    readonly entry: Entry;
+    readonly pass: 1 | 2;
+}
+
+interface PracticeState {
+    readonly queue: PracticeCard[];
+    readonly currentIndex: number;
+    readonly isFlipped: boolean;
+    readonly isComplete: boolean;
+}
+
+interface PracticeActions {
+    initSession: (entries: Entry[]) => void;
+    flip: () => void;
+    rate: (rating: PracticeRating) => void;
+}
+
+export type PracticeStore = PracticeState & PracticeActions;
+
+export const usePracticeStore = create<PracticeStore>((set) => ({
+    queue: [],
+    currentIndex: 0,
+    isFlipped: false,
+    isComplete: false,
+
+    initSession: (entries: Entry[]) => {
+        const queue: PracticeCard[] = entries.map((entry) => ({
+            entry,
+            pass: 1,
+        }));
+        set({
+            queue,
+            currentIndex: 0,
+            isFlipped: false,
+            isComplete: queue.length === 0,
+        });
+    },
+
+    flip: () => {
+        set((state) => ({ isFlipped: !state.isFlipped }));
+    },
+
+    rate: (rating: PracticeRating) => {
+        set((state) => {
+            const currentCard = state.queue[state.currentIndex];
+            if (!currentCard) return state;
+
+            let newQueue = [...state.queue];
+            if (rating === "needsWork" && currentCard.pass === 1) {
+                newQueue = [
+                    ...newQueue,
+                    { entry: currentCard.entry, pass: 2 as const },
+                ];
+            }
+
+            const nextIndex = state.currentIndex + 1;
+            const isComplete = nextIndex >= newQueue.length;
+
+            return {
+                queue: newQueue,
+                currentIndex: nextIndex,
+                isFlipped: false,
+                isComplete,
+            };
+        });
+    },
+}));

--- a/Wordfolio.Frontend/src/routeTree.gen.ts
+++ b/Wordfolio.Frontend/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as AuthenticatedDraftsEntriesEntryIdIndexRouteImport } from './ro
 import { Route as AuthenticatedDraftsEntriesEntryIdEditRouteImport } from './routes/_authenticated/drafts/entries/$entryId/edit'
 import { Route as AuthenticatedCollectionsCollectionIdVocabulariesNewRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/new'
 import { Route as AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/index'
+import { Route as AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice'
 import { Route as AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit'
 import { Route as AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/new'
 import { Route as AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdIndexRouteImport } from './routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/index'
@@ -120,6 +121,14 @@ const AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute =
       getParentRoute: () => AuthenticatedRoute,
     } as any,
   )
+const AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute =
+  AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRouteImport.update(
+    {
+      id: '/collections/$collectionId/vocabularies/$vocabularyId/practice',
+      path: '/collections/$collectionId/vocabularies/$vocabularyId/practice',
+      getParentRoute: () => AuthenticatedRoute,
+    } as any,
+  )
 const AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute =
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRouteImport.update(
     {
@@ -169,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/drafts/entries/$entryId/edit': typeof AuthenticatedDraftsEntriesEntryIdEditRoute
   '/drafts/entries/$entryId': typeof AuthenticatedDraftsEntriesEntryIdIndexRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute
+  '/collections/$collectionId/vocabularies/$vocabularyId/practice': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute
   '/collections/$collectionId/vocabularies/$vocabularyId': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/entries/new': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdEditRoute
@@ -190,6 +200,7 @@ export interface FileRoutesByTo {
   '/drafts/entries/$entryId/edit': typeof AuthenticatedDraftsEntriesEntryIdEditRoute
   '/drafts/entries/$entryId': typeof AuthenticatedDraftsEntriesEntryIdIndexRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute
+  '/collections/$collectionId/vocabularies/$vocabularyId/practice': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute
   '/collections/$collectionId/vocabularies/$vocabularyId': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/entries/new': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute
   '/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdEditRoute
@@ -213,6 +224,7 @@ export interface FileRoutesById {
   '/_authenticated/drafts/entries/$entryId/edit': typeof AuthenticatedDraftsEntriesEntryIdEditRoute
   '/_authenticated/drafts/entries/$entryId/': typeof AuthenticatedDraftsEntriesEntryIdIndexRoute
   '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute
+  '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute
   '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute
   '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/new': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute
   '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit': typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdEditRoute
@@ -236,6 +248,7 @@ export interface FileRouteTypes {
     | '/drafts/entries/$entryId/edit'
     | '/drafts/entries/$entryId'
     | '/collections/$collectionId/vocabularies/$vocabularyId/edit'
+    | '/collections/$collectionId/vocabularies/$vocabularyId/practice'
     | '/collections/$collectionId/vocabularies/$vocabularyId'
     | '/collections/$collectionId/vocabularies/$vocabularyId/entries/new'
     | '/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit'
@@ -257,6 +270,7 @@ export interface FileRouteTypes {
     | '/drafts/entries/$entryId/edit'
     | '/drafts/entries/$entryId'
     | '/collections/$collectionId/vocabularies/$vocabularyId/edit'
+    | '/collections/$collectionId/vocabularies/$vocabularyId/practice'
     | '/collections/$collectionId/vocabularies/$vocabularyId'
     | '/collections/$collectionId/vocabularies/$vocabularyId/entries/new'
     | '/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit'
@@ -279,6 +293,7 @@ export interface FileRouteTypes {
     | '/_authenticated/drafts/entries/$entryId/edit'
     | '/_authenticated/drafts/entries/$entryId/'
     | '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit'
+    | '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice'
     | '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/'
     | '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/new'
     | '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/entries/$entryId/edit'
@@ -407,6 +422,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice': {
+      id: '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice'
+      path: '/collections/$collectionId/vocabularies/$vocabularyId/practice'
+      fullPath: '/collections/$collectionId/vocabularies/$vocabularyId/practice'
+      preLoaderRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit': {
       id: '/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/edit'
       path: '/collections/$collectionId/vocabularies/$vocabularyId/edit'
@@ -450,6 +472,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedDraftsEntriesEntryIdEditRoute: typeof AuthenticatedDraftsEntriesEntryIdEditRoute
   AuthenticatedDraftsEntriesEntryIdIndexRoute: typeof AuthenticatedDraftsEntriesEntryIdIndexRoute
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute
+  AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdEditRoute: typeof AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesEntryIdEditRoute
@@ -474,6 +497,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedDraftsEntriesEntryIdIndexRoute,
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute:
     AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEditRoute,
+  AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute:
+    AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdPracticeRoute,
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute:
     AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdIndexRoute,
   AuthenticatedCollectionsCollectionIdVocabulariesVocabularyIdEntriesNewRoute:

--- a/Wordfolio.Frontend/src/routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice.tsx
+++ b/Wordfolio.Frontend/src/routes/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PracticePage } from "../../../../../../features/vocabularies/pages/PracticePage";
+import { vocabularyRouteParamsSchema } from "../../../../../../features/vocabularies/schemas/vocabularySchemas";
+
+export const Route = createFileRoute(
+    "/_authenticated/collections/$collectionId/vocabularies/$vocabularyId/practice"
+)({
+    component: PracticePage,
+    params: {
+        parse: (params) => vocabularyRouteParamsSchema.parse(params),
+    },
+});

--- a/Wordfolio.Frontend/tests/features/vocabularies/components/FlashCard.test.tsx
+++ b/Wordfolio.Frontend/tests/features/vocabularies/components/FlashCard.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FlashCard } from "../../../../src/features/vocabularies/components/FlashCard";
+import type { Entry } from "../../../../src/shared/api/types/entries";
+import {
+    DefinitionSource,
+    TranslationSource,
+} from "../../../../src/shared/api/types/entries";
+
+const makeEntry = (overrides: Partial<Entry> = {}): Entry => ({
+    id: "e1",
+    vocabularyId: "v1",
+    entryText: "bonjour",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    definitions: [],
+    translations: [],
+    ...overrides,
+});
+
+describe("FlashCard", () => {
+    it("shows entry text on front side", () => {
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={false} onFlip={vi.fn()} />
+        );
+
+        expect(screen.getByText("bonjour")).toBeInTheDocument();
+    });
+
+    it("shows tap hint on front side", () => {
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={false} onFlip={vi.fn()} />
+        );
+
+        expect(screen.getByText("Tap to reveal")).toBeInTheDocument();
+    });
+
+    it("shows definitions on back side", () => {
+        const entry = makeEntry({
+            definitions: [
+                {
+                    id: "d1",
+                    definitionText: "hello in French",
+                    source: DefinitionSource.Manual,
+                    displayOrder: 0,
+                    examples: [],
+                },
+            ],
+        });
+
+        render(<FlashCard entry={entry} isFlipped={true} onFlip={vi.fn()} />);
+
+        expect(screen.getByText("hello in French")).toBeInTheDocument();
+    });
+
+    it("shows translations on back side", () => {
+        const entry = makeEntry({
+            translations: [
+                {
+                    id: "t1",
+                    translationText: "hello",
+                    source: TranslationSource.Manual,
+                    displayOrder: 0,
+                    examples: [],
+                },
+            ],
+        });
+
+        render(<FlashCard entry={entry} isFlipped={true} onFlip={vi.fn()} />);
+
+        expect(screen.getByText("hello")).toBeInTheDocument();
+    });
+
+    it("does not show tap hint on back side", () => {
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={true} onFlip={vi.fn()} />
+        );
+
+        expect(screen.queryByText("Tap to reveal")).not.toBeInTheDocument();
+    });
+
+    it("calls onFlip when clicked", async () => {
+        const onFlip = vi.fn();
+
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={false} onFlip={onFlip} />
+        );
+
+        await userEvent.click(screen.getByRole("button"));
+
+        expect(onFlip).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onFlip when Enter is pressed", async () => {
+        const onFlip = vi.fn();
+
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={false} onFlip={onFlip} />
+        );
+
+        screen.getByRole("button").focus();
+        await userEvent.keyboard("{Enter}");
+
+        expect(onFlip).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onFlip when Space is pressed", async () => {
+        const onFlip = vi.fn();
+
+        render(
+            <FlashCard entry={makeEntry()} isFlipped={false} onFlip={onFlip} />
+        );
+
+        screen.getByRole("button").focus();
+        await userEvent.keyboard(" ");
+
+        expect(onFlip).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Wordfolio.Frontend/tests/features/vocabularies/pages/PracticePage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/vocabularies/pages/PracticePage.test.tsx
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { PracticePage } from "../../../../src/features/vocabularies/pages/PracticePage";
+import { usePracticeStore } from "../../../../src/features/vocabularies/stores/practiceStore";
+import type { Entry } from "../../../../src/shared/api/types/entries";
+import {
+    DefinitionSource,
+    TranslationSource,
+} from "../../../../src/shared/api/types/entries";
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+    useNavigate: () => mockNavigate,
+    getRouteApi: () => ({
+        useParams: () => ({
+            collectionId: "col-1",
+            vocabularyId: "voc-1",
+        }),
+        useNavigate: () => mockNavigate,
+    }),
+}));
+
+let mockVocabularyData: {
+    data: unknown;
+    isLoading: boolean;
+    isError: boolean;
+    refetch: ReturnType<typeof vi.fn>;
+} = {
+    data: { id: "voc-1", name: "French", collectionName: "Languages" },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+let mockEntriesData: {
+    data: Entry[] | undefined;
+    isLoading: boolean;
+    isError: boolean;
+    refetch: ReturnType<typeof vi.fn>;
+} = {
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+vi.mock("../../../../src/shared/api/queries/vocabularies", () => ({
+    useVocabularyDetailQuery: () => mockVocabularyData,
+}));
+
+vi.mock("../../../../src/shared/api/queries/entries", () => ({
+    useVocabularyEntriesQuery: () => mockEntriesData,
+}));
+
+const makeEntry = (id: string, text: string): Entry => ({
+    id,
+    vocabularyId: "voc-1",
+    entryText: text,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    definitions: [
+        {
+            id: `${id}-def`,
+            definitionText: `${text} definition`,
+            source: DefinitionSource.Manual,
+            displayOrder: 0,
+            examples: [],
+        },
+    ],
+    translations: [
+        {
+            id: `${id}-trans`,
+            translationText: `${text} translation`,
+            source: TranslationSource.Manual,
+            displayOrder: 0,
+            examples: [],
+        },
+    ],
+});
+
+const entry1 = makeEntry("e1", "bonjour");
+const entry2 = makeEntry("e2", "merci");
+
+const renderPage = () => {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={client}>
+            <PracticePage />
+        </QueryClientProvider>
+    );
+};
+
+describe("PracticePage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockVocabularyData = {
+            data: { id: "voc-1", name: "French", collectionName: "Languages" },
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+        mockEntriesData = {
+            data: [],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+        act(() => {
+            usePracticeStore.getState().initSession([]);
+        });
+    });
+
+    it("renders loading skeleton while data is loading", () => {
+        mockEntriesData = {
+            data: undefined,
+            isLoading: true,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        expect(screen.queryByText("Tap to reveal")).not.toBeInTheDocument();
+    });
+
+    it("renders error state when query fails", () => {
+        mockEntriesData = {
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        expect(
+            screen.getByText("Failed to Load Vocabulary")
+        ).toBeInTheDocument();
+    });
+
+    it("renders empty state when vocabulary has no entries", () => {
+        mockEntriesData = {
+            data: [],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        expect(screen.getByText("No entries to practice")).toBeInTheDocument();
+    });
+
+    it("shows first card front text when session starts", () => {
+        mockEntriesData = {
+            data: [entry1, entry2],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        expect(screen.getByText("bonjour")).toBeInTheDocument();
+        expect(screen.getByText("Tap to reveal")).toBeInTheDocument();
+    });
+
+    it("shows progress indicator", () => {
+        mockEntriesData = {
+            data: [entry1, entry2],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    });
+
+    it("flips card to show definitions on click", async () => {
+        mockEntriesData = {
+            data: [entry1],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+
+        expect(screen.getByText("bonjour definition")).toBeInTheDocument();
+        expect(screen.queryByText("Tap to reveal")).not.toBeInTheDocument();
+    });
+
+    it("shows rating buttons after flipping", async () => {
+        mockEntriesData = {
+            data: [entry1],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+
+        expect(
+            screen.getByRole("button", { name: "Easy" })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Hard" })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Needs Work" })
+        ).toBeInTheDocument();
+    });
+
+    it("advances to next card after rating Easy", async () => {
+        mockEntriesData = {
+            data: [entry1, entry2],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+        await userEvent.click(screen.getByRole("button", { name: "Easy" }));
+
+        expect(screen.getByText("merci")).toBeInTheDocument();
+        expect(screen.getByText("2 / 2")).toBeInTheDocument();
+    });
+
+    it("shows completion screen when all cards are rated", async () => {
+        mockEntriesData = {
+            data: [entry1],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+        await userEvent.click(screen.getByRole("button", { name: "Easy" }));
+
+        expect(screen.getByText("Session Complete!")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Practice Again" })
+        ).toBeInTheDocument();
+    });
+
+    it("restarts session when Practice Again is clicked", async () => {
+        mockEntriesData = {
+            data: [entry1],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+        await userEvent.click(screen.getByRole("button", { name: "Easy" }));
+        await userEvent.click(
+            screen.getByRole("button", { name: "Practice Again" })
+        );
+
+        expect(screen.getByText("bonjour")).toBeInTheDocument();
+        expect(screen.getByText("Tap to reveal")).toBeInTheDocument();
+    });
+
+    it("requeues a Needs Work card for pass 2", async () => {
+        mockEntriesData = {
+            data: [entry1, entry2],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole("button", { name: /card front/i })
+        );
+        await userEvent.click(
+            screen.getByRole("button", { name: "Needs Work" })
+        );
+
+        expect(screen.getByText("merci")).toBeInTheDocument();
+        expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    });
+});

--- a/Wordfolio.Frontend/tests/features/vocabularies/stores/practiceStore.test.ts
+++ b/Wordfolio.Frontend/tests/features/vocabularies/stores/practiceStore.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "@testing-library/react";
+
+import {
+    usePracticeStore,
+    type PracticeCard,
+} from "../../../../src/features/vocabularies/stores/practiceStore";
+import type { Entry } from "../../../../src/shared/api/types/entries";
+
+const makeEntry = (id: string, entryText = id): Entry => ({
+    id,
+    vocabularyId: "vocab-1",
+    entryText,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    definitions: [],
+    translations: [],
+});
+
+const entry1 = makeEntry("e1", "hello");
+const entry2 = makeEntry("e2", "world");
+const entry3 = makeEntry("e3", "test");
+
+describe("usePracticeStore", () => {
+    beforeEach(() => {
+        act(() => {
+            usePracticeStore.getState().initSession([]);
+        });
+    });
+
+    describe("initSession", () => {
+        it("builds a pass-1 queue from entries", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1, entry2]);
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(2);
+            expect(state.queue[0]).toEqual<PracticeCard>({
+                entry: entry1,
+                pass: 1,
+            });
+            expect(state.queue[1]).toEqual<PracticeCard>({
+                entry: entry2,
+                pass: 1,
+            });
+        });
+
+        it("resets currentIndex to 0", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1, entry2]);
+                usePracticeStore.getState().rate("easy");
+            });
+
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+            });
+
+            expect(usePracticeStore.getState().currentIndex).toBe(0);
+        });
+
+        it("resets isFlipped to false", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().flip();
+            });
+
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+            });
+
+            expect(usePracticeStore.getState().isFlipped).toBe(false);
+        });
+
+        it("marks session complete immediately when given empty entries", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([]);
+            });
+
+            expect(usePracticeStore.getState().isComplete).toBe(true);
+        });
+
+        it("marks session not complete when entries are provided", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+            });
+
+            expect(usePracticeStore.getState().isComplete).toBe(false);
+        });
+    });
+
+    describe("flip", () => {
+        it("toggles isFlipped from false to true", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().flip();
+            });
+
+            expect(usePracticeStore.getState().isFlipped).toBe(true);
+        });
+
+        it("toggles isFlipped from true to false", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().flip();
+                usePracticeStore.getState().flip();
+            });
+
+            expect(usePracticeStore.getState().isFlipped).toBe(false);
+        });
+    });
+
+    describe("rate", () => {
+        it("advances to the next card", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1, entry2]);
+                usePracticeStore.getState().rate("easy");
+            });
+
+            expect(usePracticeStore.getState().currentIndex).toBe(1);
+        });
+
+        it("resets isFlipped after rating", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1, entry2]);
+                usePracticeStore.getState().flip();
+                usePracticeStore.getState().rate("easy");
+            });
+
+            expect(usePracticeStore.getState().isFlipped).toBe(false);
+        });
+
+        it("does NOT requeue on easy (pass 1)", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().rate("easy");
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(1);
+            expect(state.isComplete).toBe(true);
+        });
+
+        it("does NOT requeue on hard (pass 1)", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().rate("hard");
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(1);
+            expect(state.isComplete).toBe(true);
+        });
+
+        it("requeues on needsWork (pass 1) appended once for pass 2", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().rate("needsWork");
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(2);
+            expect(state.queue[1]).toEqual<PracticeCard>({
+                entry: entry1,
+                pass: 2,
+            });
+            expect(state.isComplete).toBe(false);
+        });
+
+        it("does NOT requeue on needsWork (pass 2)", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1]);
+                usePracticeStore.getState().rate("needsWork");
+                usePracticeStore.getState().rate("needsWork");
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(2);
+            expect(state.isComplete).toBe(true);
+        });
+
+        it("marks session complete when last card is rated", () => {
+            act(() => {
+                usePracticeStore.getState().initSession([entry1, entry2]);
+                usePracticeStore.getState().rate("easy");
+                usePracticeStore.getState().rate("hard");
+            });
+
+            expect(usePracticeStore.getState().isComplete).toBe(true);
+        });
+
+        it("handles multiple entries with mixed ratings and requeueing", () => {
+            act(() => {
+                usePracticeStore
+                    .getState()
+                    .initSession([entry1, entry2, entry3]);
+                usePracticeStore.getState().rate("easy");
+                usePracticeStore.getState().rate("needsWork");
+                usePracticeStore.getState().rate("hard");
+            });
+
+            const state = usePracticeStore.getState();
+            expect(state.queue).toHaveLength(4);
+            expect(state.queue[3]).toEqual<PracticeCard>({
+                entry: entry2,
+                pass: 2,
+            });
+            expect(state.isComplete).toBe(false);
+
+            act(() => {
+                usePracticeStore.getState().rate("easy");
+            });
+
+            expect(usePracticeStore.getState().isComplete).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add a vocabulary practice route with a flashcard session driven by feature-local Zustand state
- wire the vocabulary detail page to launch practice, keep the page in the shared layout shell, and use shared page header/breadcrumb patterns
- ignore Playwright MCP artifacts and keep tests aligned with the practice flow and review feedback

## Validation
- cd Wordfolio.Frontend && npm run format
- cd Wordfolio.Frontend && npm test
- cd Wordfolio.Frontend && npm run lint
- cd Wordfolio.Frontend && npm run build