### PR TITLE
Fix session expiry redirect to include current path

### DIFF
--- a/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
+++ b/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
@@ -1,15 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 
 import { useRefreshMutation } from "../../../shared/api/mutations/auth";
 import { useAuthStore } from "../../../shared/stores/authStore";
 import { getSafeRedirectPath } from "../../../shared/utils/redirectUtils";
+import { loginPath } from "../routes";
 
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 export const useTokenRefresh = () => {
     const { authTokens, setTokens, clearAuth } = useAuthStore();
     const navigate = useNavigate();
+    const router = useRouter();
     const [isInitializing, setIsInitializing] = useState(true);
     const refreshTimeoutRef = useRef<number | null>(null);
     const hasInitializedRef = useRef(false);
@@ -22,11 +24,11 @@ export const useTokenRefresh = () => {
         onError: () => {
             clearAuth();
             setIsInitializing(false);
-            const currentPath =
-                window.location.pathname + window.location.search;
-            const safeRedirect = getSafeRedirectPath(currentPath);
+            const safeRedirect = getSafeRedirectPath(
+                router.state.location.href
+            );
             navigate({
-                to: "/login",
+                ...loginPath(),
                 search: {
                     message: "Your session has expired. Please log in again.",
                     ...(safeRedirect !== undefined && {

--- a/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
+++ b/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useRefreshMutation } from "../../../shared/api/mutations/auth";
 import { useAuthStore } from "../../../shared/stores/authStore";
-import { loginPath } from "../routes";
+import { getSafeRedirectPath } from "../../../shared/utils/redirectUtils";
 
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
@@ -22,10 +22,16 @@ export const useTokenRefresh = () => {
         onError: () => {
             clearAuth();
             setIsInitializing(false);
+            const currentPath =
+                window.location.pathname + window.location.search;
+            const safeRedirect = getSafeRedirectPath(currentPath);
             navigate({
-                ...loginPath(),
+                to: "/login",
                 search: {
                     message: "Your session has expired. Please log in again.",
+                    ...(safeRedirect !== undefined && {
+                        redirect: safeRedirect,
+                    }),
                 },
                 replace: true,
             });

--- a/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
@@ -6,12 +6,13 @@ import { ReactNode } from "react";
 import { useTokenRefresh } from "../../../../src/features/auth/hooks/useTokenRefresh";
 import { useAuthStore } from "../../../../src/shared/stores/authStore";
 
+const mockNavigate = vi.fn();
 const mockRefreshMutate = vi.fn();
 let mockRefreshIsPending = false;
 let mockRefreshOnError: (() => void) | undefined;
 
 vi.mock("@tanstack/react-router", () => ({
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
     getRouteApi: () => ({}),
 }));
 
@@ -43,6 +44,7 @@ const createWrapper = () => {
 describe("useTokenRefresh", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.unstubAllGlobals();
         mockRefreshIsPending = false;
         mockRefreshOnError = undefined;
         act(() => {
@@ -182,5 +184,80 @@ describe("useTokenRefresh", () => {
         const state = useAuthStore.getState();
         expect(state.authTokens).toBeNull();
         expect(state.isAuthenticated).toBe(false);
+    });
+
+    it("should navigate to login with redirect when refresh fails on a protected page", async () => {
+        vi.stubGlobal("location", { pathname: "/dashboard", search: "" });
+
+        const mockTokens = {
+            tokenType: "Bearer",
+            accessToken: "old-token",
+            expiresIn: 3600,
+            refreshToken: "invalid-token",
+            setAt: Date.now(),
+        };
+
+        act(() => {
+            useAuthStore.setState({
+                authTokens: mockTokens,
+                isAuthenticated: true,
+            });
+        });
+
+        await act(async () => {
+            renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+        });
+
+        await act(async () => {
+            mockRefreshOnError?.();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: "/login",
+            search: {
+                message: "Your session has expired. Please log in again.",
+                redirect: "/dashboard",
+            },
+            replace: true,
+        });
+    });
+
+    it("should navigate to login without redirect when refresh fails on the login page", async () => {
+        vi.stubGlobal("location", { pathname: "/login", search: "" });
+
+        const mockTokens = {
+            tokenType: "Bearer",
+            accessToken: "old-token",
+            expiresIn: 3600,
+            refreshToken: "invalid-token",
+            setAt: Date.now(),
+        };
+
+        act(() => {
+            useAuthStore.setState({
+                authTokens: mockTokens,
+                isAuthenticated: true,
+            });
+        });
+
+        await act(async () => {
+            renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+        });
+
+        await act(async () => {
+            mockRefreshOnError?.();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith({
+            to: "/login",
+            search: {
+                message: "Your session has expired. Please log in again.",
+            },
+            replace: true,
+        });
     });
 });

--- a/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
@@ -10,9 +10,11 @@ const mockNavigate = vi.fn();
 const mockRefreshMutate = vi.fn();
 let mockRefreshIsPending = false;
 let mockRefreshOnError: (() => void) | undefined;
+let mockRouterHref = "/";
 
 vi.mock("@tanstack/react-router", () => ({
     useNavigate: () => mockNavigate,
+    useRouter: () => ({ state: { location: { href: mockRouterHref } } }),
     getRouteApi: () => ({}),
 }));
 
@@ -47,6 +49,7 @@ describe("useTokenRefresh", () => {
         vi.unstubAllGlobals();
         mockRefreshIsPending = false;
         mockRefreshOnError = undefined;
+        mockRouterHref = "/";
         act(() => {
             useAuthStore.setState({
                 authTokens: null,
@@ -187,7 +190,7 @@ describe("useTokenRefresh", () => {
     });
 
     it("should navigate to login with redirect when refresh fails on a protected page", async () => {
-        vi.stubGlobal("location", { pathname: "/dashboard", search: "" });
+        mockRouterHref = "/dashboard";
 
         const mockTokens = {
             tokenType: "Bearer",
@@ -225,7 +228,7 @@ describe("useTokenRefresh", () => {
     });
 
     it("should navigate to login without redirect when refresh fails on the login page", async () => {
-        vi.stubGlobal("location", { pathname: "/login", search: "" });
+        mockRouterHref = "/login";
 
         const mockTokens = {
             tokenType: "Bearer",


### PR DESCRIPTION
## Summary

Fixes #254

When a token refresh fails (session expires), the app now redirects to `/login` with the user's current path included as the `redirect` search param, so they can be taken back after logging in again.

## Changes

### `useTokenRefresh.ts`
- Add `useRouter()` to read `router.state.location.href` inside the `onError` callback (replaces prior `window.location` approach)
- Sanitize the path using `getSafeRedirectPath` to prevent auth loops (omits `redirect` when already on `/login` or `/register`)
- Navigate via `loginPath()` spread into `navigate()`, always including the session-expiry `message`; include `redirect` only when the sanitized path is defined

### `useTokenRefresh.test.tsx`
- Promote `mockNavigate` to a shared module-level mock so navigate calls can be asserted
- Mock `useRouter` to expose a controllable `router.state.location.href` value
- Add `vi.unstubAllGlobals()` to `beforeEach` cleanup
- Add test: refresh failure on a protected page includes `redirect` + `message`
- Add test: refresh failure on `/login` omits `redirect` but still includes `message`