### PR TITLE
fix: resolve error state inconsistencies across detail pages and register

### DIFF
--- a/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
@@ -101,8 +101,8 @@ export const RegisterPage = () => {
             return (
                 <div className={styles.stateBlock}>
                     <RetryOnError
-                        title="Failed to Load Password Requirements"
-                        description="Something went wrong while loading password requirements. Please try again."
+                        title="Failed to Load Registration"
+                        description="Something went wrong while loading registration. Please try again."
                         onRetry={() => void refetchPasswordRequirements()}
                     />
                 </div>

--- a/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
@@ -101,8 +101,6 @@ export const RegisterPage = () => {
             return (
                 <div className={styles.stateBlock}>
                     <RetryOnError
-                        title="Failed to Load Registration"
-                        description="Something went wrong while loading registration. Please try again."
                         onRetry={() => void refetchPasswordRequirements()}
                     />
                 </div>

--- a/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/Wordfolio.Frontend/src/features/auth/pages/RegisterPage.tsx
@@ -101,6 +101,8 @@ export const RegisterPage = () => {
             return (
                 <div className={styles.stateBlock}>
                     <RetryOnError
+                        title="Failed to Load Password Requirements"
+                        description="Something went wrong while loading password requirements. Please try again."
                         onRetry={() => void refetchPasswordRequirements()}
                     />
                 </div>

--- a/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/collections/pages/CollectionDetailPage.tsx
@@ -181,21 +181,24 @@ export const CollectionDetailPage = () => {
                 }
                 description={collection?.description ?? undefined}
                 actions={
-                    <PageHeaderActions
-                        actions={[
-                            {
-                                label: "Edit",
-                                onClick: handleEditClick,
-                                disabled: isLoading,
-                            },
-                            {
-                                label: "Delete",
-                                onClick: handleDelete,
-                                color: "error",
-                                disabled: isLoading || deleteMutation.isPending,
-                            },
-                        ]}
-                    />
+                    isError ? undefined : (
+                        <PageHeaderActions
+                            actions={[
+                                {
+                                    label: "Edit",
+                                    onClick: handleEditClick,
+                                    disabled: isLoading,
+                                },
+                                {
+                                    label: "Delete",
+                                    onClick: handleDelete,
+                                    color: "error",
+                                    disabled:
+                                        isLoading || deleteMutation.isPending,
+                                },
+                            ]}
+                        />
+                    )
                 }
             />
             {renderContent()}

--- a/Wordfolio.Frontend/src/features/entries/pages/EntryDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/entries/pages/EntryDetailPage.tsx
@@ -196,26 +196,30 @@ export const EntryDetailPage = () => {
                         : undefined
                 }
                 actions={
-                    <PageHeaderActions
-                        actions={[
-                            {
-                                label: "Move",
-                                onClick: handleMoveClick,
-                                disabled: isLoading || moveMutation.isPending,
-                            },
-                            {
-                                label: "Edit",
-                                onClick: handleEditClick,
-                                disabled: isLoading,
-                            },
-                            {
-                                label: "Delete",
-                                onClick: handleDeleteClick,
-                                color: "error",
-                                disabled: isLoading || deleteMutation.isPending,
-                            },
-                        ]}
-                    />
+                    isError ? undefined : (
+                        <PageHeaderActions
+                            actions={[
+                                {
+                                    label: "Move",
+                                    onClick: handleMoveClick,
+                                    disabled:
+                                        isLoading || moveMutation.isPending,
+                                },
+                                {
+                                    label: "Edit",
+                                    onClick: handleEditClick,
+                                    disabled: isLoading,
+                                },
+                                {
+                                    label: "Delete",
+                                    onClick: handleDeleteClick,
+                                    color: "error",
+                                    disabled:
+                                        isLoading || deleteMutation.isPending,
+                                },
+                            ]}
+                        />
+                    )
                 }
             />
             {renderContent()}

--- a/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
+++ b/Wordfolio.Frontend/src/features/vocabularies/pages/VocabularyDetailPage.tsx
@@ -207,8 +207,8 @@ export const VocabularyDetailPage = () => {
 
             return (
                 <RetryOnError
-                    title="Failed to Load Data"
-                    description="Something went wrong while loading the data. Please try again."
+                    title="Failed to Load Vocabulary"
+                    description="Something went wrong while loading this vocabulary. Please try again."
                     onRetry={handleRetry}
                 />
             );
@@ -247,31 +247,35 @@ export const VocabularyDetailPage = () => {
                 }
                 description={vocabulary?.description ?? undefined}
                 actions={
-                    <PageHeaderActions
-                        actions={[
-                            {
-                                label: "Practice",
-                                onClick: handlePracticeClick,
-                                disabled: isLoading || !entries?.length,
-                            },
-                            {
-                                label: "Move",
-                                onClick: handleMoveClick,
-                                disabled: isLoading || moveMutation.isPending,
-                            },
-                            {
-                                label: "Edit",
-                                onClick: handleEditClick,
-                                disabled: isLoading,
-                            },
-                            {
-                                label: "Delete",
-                                onClick: handleDeleteClick,
-                                color: "error",
-                                disabled: isLoading || deleteMutation.isPending,
-                            },
-                        ]}
-                    />
+                    isError ? undefined : (
+                        <PageHeaderActions
+                            actions={[
+                                {
+                                    label: "Practice",
+                                    onClick: handlePracticeClick,
+                                    disabled: isLoading || !entries?.length,
+                                },
+                                {
+                                    label: "Move",
+                                    onClick: handleMoveClick,
+                                    disabled:
+                                        isLoading || moveMutation.isPending,
+                                },
+                                {
+                                    label: "Edit",
+                                    onClick: handleEditClick,
+                                    disabled: isLoading,
+                                },
+                                {
+                                    label: "Delete",
+                                    onClick: handleDeleteClick,
+                                    color: "error",
+                                    disabled:
+                                        isLoading || deleteMutation.isPending,
+                                },
+                            ]}
+                        />
+                    )
                 }
             />
             {renderContent()}

--- a/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
@@ -186,7 +186,7 @@ describe("RegisterPage", () => {
         });
     });
 
-    it("shows password requirements error title when requirements fail to load", () => {
+    it("shows generic registration error title when requirements fail to load", () => {
         mockPasswordRequirementsQuery = {
             data: undefined,
             isLoading: false,
@@ -197,7 +197,7 @@ describe("RegisterPage", () => {
         render(<RegisterPage />, { wrapper: createWrapper() });
 
         expect(
-            screen.getByText("Failed to Load Password Requirements")
+            screen.getByText("Failed to Load Registration")
         ).toBeInTheDocument();
     });
 });

--- a/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
@@ -69,13 +69,17 @@ vi.mock("../../../../src/shared/api/mutations/auth", () => ({
     },
 }));
 
+let mockPasswordRequirementsQuery = {
+    data: mockPasswordRequirements as
+        | typeof mockPasswordRequirements
+        | undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
 vi.mock("../../../../src/shared/api/queries/auth", () => ({
-    usePasswordRequirementsQuery: () => ({
-        data: mockPasswordRequirements,
-        isLoading: false,
-        isError: false,
-        refetch: vi.fn(),
-    }),
+    usePasswordRequirementsQuery: () => mockPasswordRequirementsQuery,
 }));
 
 vi.mock("../../../../src/shared/stores/authStore", () => ({
@@ -106,6 +110,12 @@ describe("RegisterPage", () => {
         mockRegisterMutate = vi.fn();
         mockRegisterIsPending = false;
         mockRegisterOnSuccess = undefined;
+        mockPasswordRequirementsQuery = {
+            data: mockPasswordRequirements,
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
     });
 
     it("stores tokens and navigates home when no redirect is present", async () => {
@@ -174,5 +184,20 @@ describe("RegisterPage", () => {
             email: "test@example.com",
             password: "password123",
         });
+    });
+
+    it("shows password requirements error title when requirements fail to load", () => {
+        mockPasswordRequirementsQuery = {
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        render(<RegisterPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.getByText("Failed to Load Password Requirements")
+        ).toBeInTheDocument();
     });
 });

--- a/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/pages/RegisterPage.test.tsx
@@ -186,7 +186,7 @@ describe("RegisterPage", () => {
         });
     });
 
-    it("shows generic registration error title when requirements fail to load", () => {
+    it("uses the default retry error copy when requirements fail to load", () => {
         mockPasswordRequirementsQuery = {
             data: undefined,
             isLoading: false,
@@ -196,8 +196,11 @@ describe("RegisterPage", () => {
 
         render(<RegisterPage />, { wrapper: createWrapper() });
 
+        expect(screen.getByText("Something went wrong")).toBeInTheDocument();
         expect(
-            screen.getByText("Failed to Load Registration")
+            screen.getByText(
+                "We had trouble loading this content. Please try again."
+            )
         ).toBeInTheDocument();
     });
 });

--- a/Wordfolio.Frontend/tests/features/collections/pages/CollectionDetailPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/collections/pages/CollectionDetailPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { CollectionDetailPage } from "../../../../src/features/collections/pages/CollectionDetailPage";
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+    getRouteApi: () => ({
+        useParams: () => ({ collectionId: "col-1" }),
+        useSearch: () => ({}),
+        useNavigate: () => mockNavigate,
+    }),
+}));
+
+let mockCollectionQuery = {
+    data: { id: "col-1", name: "My Collection", description: null },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+let mockVocabulariesQuery = {
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+vi.mock("../../../../src/shared/api/queries/collections", () => ({
+    useCollectionQuery: () => mockCollectionQuery,
+    useCollectionVocabulariesQuery: () => mockVocabulariesQuery,
+}));
+
+vi.mock("../../../../src/shared/api/mutations/collections", () => ({
+    useDeleteCollectionMutation: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+vi.mock("../../../../src/shared/contexts/ConfirmDialogContext", () => ({
+    useConfirmDialog: () => ({
+        raiseConfirmDialogAsync: vi.fn().mockResolvedValue(false),
+    }),
+}));
+
+vi.mock("../../../../src/shared/contexts/NotificationContext", () => ({
+    useNotificationContext: () => ({
+        openErrorNotification: vi.fn(),
+    }),
+}));
+
+vi.mock(
+    "../../../../src/features/collections/components/CollectionDetailContent",
+    () => ({
+        CollectionDetailContent: () => <div>Collection Content</div>,
+    })
+);
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+describe("CollectionDetailPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCollectionQuery = {
+            data: { id: "col-1", name: "My Collection", description: null },
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+        mockVocabulariesQuery = {
+            data: [],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+    });
+
+    it("hides actions when in error state", () => {
+        mockCollectionQuery = {
+            data: undefined as never,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        render(<CollectionDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.queryByRole("button", { name: /edit/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /delete/i })
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows actions when data loads successfully", () => {
+        render(<CollectionDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.getByRole("button", { name: /edit/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /delete/i })
+        ).toBeInTheDocument();
+    });
+});

--- a/Wordfolio.Frontend/tests/features/entries/pages/EntryDetailPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/entries/pages/EntryDetailPage.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { EntryDetailPage } from "../../../../src/features/entries/pages/EntryDetailPage";
+
+const mockNavigate = vi.fn();
+const mockInvalidateQueries = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+    useNavigate: () => mockNavigate,
+    getRouteApi: () => ({
+        useParams: () => ({
+            collectionId: "col-1",
+            vocabularyId: "voc-1",
+            entryId: "entry-1",
+        }),
+        useNavigate: () => mockNavigate,
+    }),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+    const actual =
+        await importOriginal<typeof import("@tanstack/react-query")>();
+    return {
+        ...actual,
+        useQueryClient: () => ({
+            invalidateQueries: mockInvalidateQueries,
+        }),
+    };
+});
+
+let mockVocabularyQuery = {
+    data: {
+        id: "voc-1",
+        name: "French",
+        collectionName: "Languages",
+        description: null,
+    },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+let mockEntryQuery = {
+    data: {
+        id: "entry-1",
+        entryText: "bonjour",
+        vocabularyId: "voc-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        definitions: [],
+        translations: [],
+    },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+vi.mock("../../../../src/shared/api/queries/vocabularies", () => ({
+    useVocabularyDetailQuery: () => mockVocabularyQuery,
+}));
+
+vi.mock("../../../../src/shared/api/queries/entries", () => ({
+    useEntryQuery: () => mockEntryQuery,
+}));
+
+vi.mock("../../../../src/shared/api/mutations/entries", () => ({
+    useDeleteEntryMutation: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+    useMoveEntryMutation: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+vi.mock("../../../../src/shared/hooks/useMoveEntryDialog", () => ({
+    useMoveEntryDialog: () => ({
+        raiseMoveEntryDialogAsync: vi.fn().mockResolvedValue(null),
+        dialogElement: null,
+    }),
+}));
+
+vi.mock("../../../../src/shared/contexts/ConfirmDialogContext", () => ({
+    useConfirmDialog: () => ({
+        raiseConfirmDialogAsync: vi.fn().mockResolvedValue(false),
+    }),
+}));
+
+vi.mock("../../../../src/shared/contexts/NotificationContext", () => ({
+    useNotificationContext: () => ({
+        openErrorNotification: vi.fn(),
+    }),
+}));
+
+vi.mock("../../../../src/shared/components/entries/EntryDetailContent", () => ({
+    EntryDetailContent: () => <div>Entry Content</div>,
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+describe("EntryDetailPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockVocabularyQuery = {
+            data: {
+                id: "voc-1",
+                name: "French",
+                collectionName: "Languages",
+                description: null,
+            },
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+        mockEntryQuery = {
+            data: {
+                id: "entry-1",
+                entryText: "bonjour",
+                vocabularyId: "voc-1",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                definitions: [],
+                translations: [],
+            },
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+    });
+
+    it("hides actions when in error state", () => {
+        mockEntryQuery = {
+            data: undefined as never,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        render(<EntryDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.queryByRole("button", { name: /edit/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /delete/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /move/i })
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows actions when data loads successfully", () => {
+        render(<EntryDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.getByRole("button", { name: /edit/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /delete/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /move/i })
+        ).toBeInTheDocument();
+    });
+});

--- a/Wordfolio.Frontend/tests/features/vocabularies/pages/VocabularyDetailPage.test.tsx
+++ b/Wordfolio.Frontend/tests/features/vocabularies/pages/VocabularyDetailPage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { VocabularyDetailPage } from "../../../../src/features/vocabularies/pages/VocabularyDetailPage";
+
+const mockNavigate = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+    getRouteApi: () => ({
+        useParams: () => ({
+            collectionId: "col-1",
+            vocabularyId: "voc-1",
+        }),
+        useSearch: () => ({}),
+        useNavigate: () => mockNavigate,
+    }),
+}));
+
+let mockVocabularyQuery = {
+    data: {
+        id: "voc-1",
+        name: "French",
+        collectionName: "Languages",
+        description: null,
+    },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+let mockEntriesQuery = {
+    data: [],
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+};
+
+vi.mock("../../../../src/shared/api/queries/vocabularies", () => ({
+    useVocabularyDetailQuery: () => mockVocabularyQuery,
+}));
+
+vi.mock("../../../../src/shared/api/queries/entries", () => ({
+    useVocabularyEntriesQuery: () => mockEntriesQuery,
+}));
+
+vi.mock("../../../../src/shared/api/mutations/vocabularies", () => ({
+    useDeleteVocabularyMutation: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+    useMoveVocabularyMutation: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+vi.mock(
+    "../../../../src/features/vocabularies/hooks/useMoveVocabularyDialog",
+    () => ({
+        useMoveVocabularyDialog: () => ({
+            raiseMoveVocabularyDialogAsync: vi.fn().mockResolvedValue(null),
+            dialogElement: null,
+        }),
+    })
+);
+
+vi.mock("../../../../src/shared/contexts/ConfirmDialogContext", () => ({
+    useConfirmDialog: () => ({
+        raiseConfirmDialogAsync: vi.fn().mockResolvedValue(false),
+    }),
+}));
+
+vi.mock("../../../../src/shared/contexts/NotificationContext", () => ({
+    useNotificationContext: () => ({
+        openErrorNotification: vi.fn(),
+    }),
+}));
+
+vi.mock(
+    "../../../../src/features/vocabularies/components/VocabularyDetailContent",
+    () => ({
+        VocabularyDetailContent: () => <div>Vocabulary Content</div>,
+    })
+);
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    );
+};
+
+describe("VocabularyDetailPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockVocabularyQuery = {
+            data: {
+                id: "voc-1",
+                name: "French",
+                collectionName: "Languages",
+                description: null,
+            },
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+        mockEntriesQuery = {
+            data: [],
+            isLoading: false,
+            isError: false,
+            refetch: vi.fn(),
+        };
+    });
+
+    it("hides actions when in error state", () => {
+        mockVocabularyQuery = {
+            data: undefined as never,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        render(<VocabularyDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.queryByRole("button", { name: /edit/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /delete/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /practice/i })
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /move/i })
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows actions when data loads successfully", () => {
+        render(<VocabularyDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.getByRole("button", { name: /edit/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /delete/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /practice/i })
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /move/i })
+        ).toBeInTheDocument();
+    });
+
+    it("shows updated error title when vocabulary fails to load", () => {
+        mockVocabularyQuery = {
+            data: undefined as never,
+            isLoading: false,
+            isError: true,
+            refetch: vi.fn(),
+        };
+
+        render(<VocabularyDetailPage />, { wrapper: createWrapper() });
+
+        expect(
+            screen.getByText("Failed to Load Vocabulary")
+        ).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

Closes #256

## Changes

- **Hide PageHeaderActions during error state** on CollectionDetailPage, VocabularyDetailPage, and EntryDetailPage — action buttons (Edit, Delete, Practice, Move) no longer render when data failed to load.
- **Update VocabularyDetailPage error copy** from generic `Failed to Load Data` to `Failed to Load Vocabulary` / `Something went wrong while loading this vocabulary. Please try again.`
- **Keep RegisterPage load failures on the default `RetryOnError` copy** instead of overriding the title and description.
- **Add focused frontend tests** covering all three behaviors.