### PR TITLE
fix(auth): prevent token refresh tight-loop for short-lived or expired tokens

### DIFF
--- a/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
+++ b/Wordfolio.Frontend/src/features/auth/hooks/useTokenRefresh.ts
@@ -41,25 +41,32 @@ export const useTokenRefresh = () => {
     });
 
     const scheduleTokenRefresh = useCallback(
-        (expiresIn: number) => {
+        (expiresIn: number, setAt: number) => {
             if (refreshTimeoutRef.current !== null) {
                 clearTimeout(refreshTimeoutRef.current);
             }
 
-            const refreshInMs = Math.max(
-                expiresIn * 1000 - REFRESH_BUFFER_MS,
+            const tokenLifetimeMs = expiresIn * 1000;
+            const remainingMs = Math.max(
+                setAt + tokenLifetimeMs - Date.now(),
                 0
             );
+            const effectiveBufferMs = Math.min(
+                REFRESH_BUFFER_MS,
+                Math.floor(tokenLifetimeMs / 2)
+            );
+            const delayMs = Math.max(remainingMs - effectiveBufferMs, 1000);
 
             refreshTimeoutRef.current = window.setTimeout(() => {
-                if (authTokens?.refreshToken) {
+                const currentTokens = useAuthStore.getState().authTokens;
+                if (currentTokens?.refreshToken) {
                     refreshMutation.mutate({
-                        refreshToken: authTokens.refreshToken,
+                        refreshToken: currentTokens.refreshToken,
                     });
                 }
-            }, refreshInMs);
+            }, delayMs);
         },
-        [authTokens, refreshMutation]
+        [refreshMutation]
     );
 
     useEffect(() => {
@@ -79,7 +86,7 @@ export const useTokenRefresh = () => {
 
     useEffect(() => {
         if (authTokens && !isInitializing) {
-            scheduleTokenRefresh(authTokens.expiresIn);
+            scheduleTokenRefresh(authTokens.expiresIn, authTokens.setAt);
         }
 
         return () => {

--- a/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
+++ b/Wordfolio.Frontend/tests/features/auth/hooks/useTokenRefresh.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
@@ -261,6 +261,204 @@ describe("useTokenRefresh", () => {
                 message: "Your session has expired. Please log in again.",
             },
             replace: true,
+        });
+    });
+
+    describe("timer scheduling", () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("should not refresh immediately for short TTL tokens (no tight-loop)", async () => {
+            const now = 1_000_000_000_000;
+            vi.setSystemTime(now);
+
+            const { result } = renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+
+            expect(result.current.isInitializing).toBe(false);
+
+            act(() => {
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "access-token",
+                        expiresIn: 10,
+                        refreshToken: "refresh-token",
+                        setAt: now,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(4999);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+            expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+        });
+
+        it("should refresh 5 minutes before expiry for normal TTL tokens", async () => {
+            const now = 1_000_000_000_000;
+            vi.setSystemTime(now);
+
+            const { result } = renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+
+            expect(result.current.isInitializing).toBe(false);
+
+            act(() => {
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "access-token",
+                        expiresIn: 3600,
+                        refreshToken: "refresh-token",
+                        setAt: now,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(3_299_999);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+            expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+        });
+
+        it("should use remaining lifetime for persisted tokens based on setAt", async () => {
+            const now = 1_000_000_000_000;
+            vi.setSystemTime(now);
+
+            const { result } = renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+
+            expect(result.current.isInitializing).toBe(false);
+
+            act(() => {
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "access-token",
+                        expiresIn: 3600,
+                        refreshToken: "refresh-token",
+                        setAt: now - 30 * 60 * 1000,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(1_499_999);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+            expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+        });
+
+        it("should enforce minimum 1000ms delay for expired tokens to prevent tight-loop", async () => {
+            const now = 1_000_000_000_000;
+            vi.setSystemTime(now);
+
+            const { result } = renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+
+            expect(result.current.isInitializing).toBe(false);
+
+            act(() => {
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "access-token",
+                        expiresIn: 5,
+                        refreshToken: "refresh-token",
+                        setAt: now - 10_000,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(999);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+            expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+
+            act(() => {
+                vi.setSystemTime(now + 1000);
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "new-access-token",
+                        expiresIn: 5,
+                        refreshToken: "new-refresh-token",
+                        setAt: now + 1000,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            vi.clearAllMocks();
+
+            act(() => {
+                vi.advanceTimersByTime(999);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
+        });
+
+        it("should clear pending timer on unmount", async () => {
+            const now = 1_000_000_000_000;
+            vi.setSystemTime(now);
+
+            const { result, unmount } = renderHook(() => useTokenRefresh(), {
+                wrapper: createWrapper(),
+            });
+
+            expect(result.current.isInitializing).toBe(false);
+
+            act(() => {
+                useAuthStore.setState({
+                    authTokens: {
+                        tokenType: "Bearer",
+                        accessToken: "access-token",
+                        expiresIn: 3600,
+                        refreshToken: "refresh-token",
+                        setAt: now,
+                    },
+                    isAuthenticated: true,
+                });
+            });
+
+            unmount();
+
+            act(() => {
+                vi.advanceTimersByTime(3_300_000);
+            });
+            expect(mockRefreshMutate).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #259

The `useTokenRefresh` hook could enter a tight-loop when tokens were short-lived or already expired, because:
- `REFRESH_BUFFER_MS` could exceed the full token lifetime, causing immediate re-scheduling
- Expired tokens resulted in a negative delay which resolved to `0ms`, spinning the event loop

## Changes

### `useTokenRefresh.ts`
- Accept `setAt` timestamp to compute actual remaining lifetime
- Cap `effectiveBufferMs` to half the token lifetime so the buffer never exceeds the actual TTL
- Floor `delayMs` to a minimum of `1000ms` to prevent tight-looping on already-expired tokens
- Timeout callback reads tokens from `useAuthStore.getState()` instead of the closed-over value to avoid stale closure issues

### `useTokenRefresh.test.tsx`
- Timer-based tests covering: short TTL, normal TTL, persisted tokens, expired token minimum delay, and unmount cleanup

## Verification

All existing and new tests pass locally:
- `npm test` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm run format:check` ✅