### PR TITLE
Add exercise sessions, session entries, and attempts migrations

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.Migrations/20260418001_CreateExerciseSessionsTable.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/20260418001_CreateExerciseSessionsTable.fs
@@ -1,0 +1,52 @@
+namespace Wordfolio.Api.Migrations
+
+open FluentMigrator
+
+open Constants
+
+[<Migration(20260418001L)>]
+type CreateExerciseSessionsTable() =
+    inherit AutoReversingMigration()
+
+    override this.Up() =
+        base.Create
+            .Table(ExerciseSessionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .WithColumn(ExerciseSessionsTable.IdColumn)
+            .AsInt32()
+            .PrimaryKey()
+            .Identity()
+            .WithColumn(ExerciseSessionsTable.UserIdColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseSessionsTable.ExerciseTypeColumn)
+            .AsInt16()
+            .NotNullable()
+            .WithColumn(ExerciseSessionsTable.CreatedAtColumn)
+            .AsDateTimeOffset()
+            .NotNullable()
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_ExerciseSessions_UserId_Users_Id")
+            .FromTable(ExerciseSessionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(ExerciseSessionsTable.UserIdColumn)
+            .ToTable(UsersTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn("Id")
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseSessions_UserId")
+            .OnTable(ExerciseSessionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseSessionsTable.UserIdColumn)
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseSessions_CreatedAt")
+            .OnTable(ExerciseSessionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseSessionsTable.CreatedAtColumn)
+        |> ignore

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/20260418002_CreateExerciseSessionEntriesTable.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/20260418002_CreateExerciseSessionEntriesTable.fs
@@ -1,0 +1,82 @@
+namespace Wordfolio.Api.Migrations
+
+open System.Data
+
+open FluentMigrator
+
+open Constants
+
+[<Migration(20260418002L)>]
+type CreateExerciseSessionEntriesTable() =
+    inherit AutoReversingMigration()
+
+    override this.Up() =
+        base.Create
+            .Table(ExerciseSessionEntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .WithColumn(ExerciseSessionEntriesTable.IdColumn)
+            .AsInt32()
+            .PrimaryKey()
+            .Identity()
+            .WithColumn(ExerciseSessionEntriesTable.SessionIdColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseSessionEntriesTable.EntryIdColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseSessionEntriesTable.DisplayOrderColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseSessionEntriesTable.PromptDataColumn)
+            .AsString()
+            .NotNullable()
+            .WithColumn(ExerciseSessionEntriesTable.PromptSchemaVersionColumn)
+            .AsInt16()
+            .NotNullable()
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_ExerciseSessionEntries_SessionId_ExerciseSessions_Id")
+            .FromTable(ExerciseSessionEntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(ExerciseSessionEntriesTable.SessionIdColumn)
+            .ToTable(ExerciseSessionsTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn(ExerciseSessionsTable.IdColumn)
+            .OnDelete(Rule.Cascade)
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_ExerciseSessionEntries_EntryId_Entries_Id")
+            .FromTable(ExerciseSessionEntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(ExerciseSessionEntriesTable.EntryIdColumn)
+            .ToTable(EntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn(EntriesTable.IdColumn)
+            .OnDelete(Rule.Cascade)
+        |> ignore
+
+        base.Create
+            .UniqueConstraint("UQ_ExerciseSessionEntries_SessionId_EntryId")
+            .OnTable(ExerciseSessionEntriesTable.Name)
+            .WithSchema(WordfolioSchema)
+            .Columns(
+                [| ExerciseSessionEntriesTable.SessionIdColumn
+                   ExerciseSessionEntriesTable.EntryIdColumn |]
+            )
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseSessionEntries_SessionId")
+            .OnTable(ExerciseSessionEntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseSessionEntriesTable.SessionIdColumn)
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseSessionEntries_EntryId")
+            .OnTable(ExerciseSessionEntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseSessionEntriesTable.EntryIdColumn)
+        |> ignore

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/20260418003_CreateExerciseAttemptsTable.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/20260418003_CreateExerciseAttemptsTable.fs
@@ -1,0 +1,102 @@
+namespace Wordfolio.Api.Migrations
+
+open System.Data
+
+open FluentMigrator
+
+open Constants
+
+[<Migration(20260418003L)>]
+type CreateExerciseAttemptsTable() =
+    inherit AutoReversingMigration()
+
+    override this.Up() =
+        base.Create
+            .Table(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .WithColumn(ExerciseAttemptsTable.IdColumn)
+            .AsInt32()
+            .PrimaryKey()
+            .Identity()
+            .WithColumn(ExerciseAttemptsTable.UserIdColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.SessionIdColumn)
+            .AsInt32()
+            .Nullable()
+            .WithColumn(ExerciseAttemptsTable.EntryIdColumn)
+            .AsInt32()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.ExerciseTypeColumn)
+            .AsInt16()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.PromptDataColumn)
+            .AsString()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.PromptSchemaVersionColumn)
+            .AsInt16()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.RawAnswerColumn)
+            .AsString()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.IsCorrectColumn)
+            .AsBoolean()
+            .NotNullable()
+            .WithColumn(ExerciseAttemptsTable.AttemptedAtColumn)
+            .AsDateTimeOffset()
+            .NotNullable()
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_ExerciseAttempts_UserId_Users_Id")
+            .FromTable(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(ExerciseAttemptsTable.UserIdColumn)
+            .ToTable(UsersTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn("Id")
+        |> ignore
+
+        base.Create
+            .ForeignKey("FK_ExerciseAttempts_EntryId_Entries_Id")
+            .FromTable(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .ForeignColumn(ExerciseAttemptsTable.EntryIdColumn)
+            .ToTable(EntriesTable.Name)
+            .InSchema(WordfolioSchema)
+            .PrimaryColumn(EntriesTable.IdColumn)
+            .OnDelete(Rule.Cascade)
+        |> ignore
+
+        base.Create
+            .UniqueConstraint("UQ_ExerciseAttempts_SessionId_EntryId")
+            .OnTable(ExerciseAttemptsTable.Name)
+            .WithSchema(WordfolioSchema)
+            .Columns([| ExerciseAttemptsTable.SessionIdColumn; ExerciseAttemptsTable.EntryIdColumn |])
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseAttempts_UserId_EntryId_AttemptedAt")
+            .OnTable(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseAttemptsTable.UserIdColumn)
+            .Ascending()
+            .OnColumn(ExerciseAttemptsTable.EntryIdColumn)
+            .Ascending()
+            .OnColumn(ExerciseAttemptsTable.AttemptedAtColumn)
+            .Descending()
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseAttempts_SessionId")
+            .OnTable(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseAttemptsTable.SessionIdColumn)
+        |> ignore
+
+        base.Create
+            .Index("IX_ExerciseAttempts_EntryId")
+            .OnTable(ExerciseAttemptsTable.Name)
+            .InSchema(WordfolioSchema)
+            .OnColumn(ExerciseAttemptsTable.EntryIdColumn)
+        |> ignore

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/Constants.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/Constants.fs
@@ -140,3 +140,80 @@ module ExamplesTable =
 
     [<Literal>]
     let SourceColumn = "Source"
+
+module ExerciseSessionsTable =
+
+    [<Literal>]
+    let Name = "ExerciseSessions"
+
+    [<Literal>]
+    let IdColumn = "Id"
+
+    [<Literal>]
+    let UserIdColumn = "UserId"
+
+    [<Literal>]
+    let ExerciseTypeColumn = "ExerciseType"
+
+    [<Literal>]
+    let CreatedAtColumn = "CreatedAt"
+
+module ExerciseSessionEntriesTable =
+
+    [<Literal>]
+    let Name = "ExerciseSessionEntries"
+
+    [<Literal>]
+    let IdColumn = "Id"
+
+    [<Literal>]
+    let SessionIdColumn = "SessionId"
+
+    [<Literal>]
+    let EntryIdColumn = "EntryId"
+
+    [<Literal>]
+    let DisplayOrderColumn = "DisplayOrder"
+
+    [<Literal>]
+    let PromptDataColumn = "PromptData"
+
+    [<Literal>]
+    let PromptSchemaVersionColumn =
+        "PromptSchemaVersion"
+
+module ExerciseAttemptsTable =
+
+    [<Literal>]
+    let Name = "ExerciseAttempts"
+
+    [<Literal>]
+    let IdColumn = "Id"
+
+    [<Literal>]
+    let UserIdColumn = "UserId"
+
+    [<Literal>]
+    let SessionIdColumn = "SessionId"
+
+    [<Literal>]
+    let EntryIdColumn = "EntryId"
+
+    [<Literal>]
+    let ExerciseTypeColumn = "ExerciseType"
+
+    [<Literal>]
+    let PromptDataColumn = "PromptData"
+
+    [<Literal>]
+    let PromptSchemaVersionColumn =
+        "PromptSchemaVersion"
+
+    [<Literal>]
+    let RawAnswerColumn = "RawAnswer"
+
+    [<Literal>]
+    let IsCorrectColumn = "IsCorrect"
+
+    [<Literal>]
+    let AttemptedAtColumn = "AttemptedAt"

--- a/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.Migrations/Wordfolio.Api.Migrations.fsproj
@@ -18,6 +18,9 @@
     <Compile Include="20260110001_AddSystemCollectionsAndDefaultVocabularies.fs" />
     <Compile Include="20260321001_AddCascadeDeleteToVocabulariesCollectionForeignKey.fs" />
     <Compile Include="20260401001_MakeUpdatedAtNotNull.fs" />
+    <Compile Include="20260418001_CreateExerciseSessionsTable.fs" />
+    <Compile Include="20260418002_CreateExerciseSessionEntriesTable.fs" />
+    <Compile Include="20260418003_CreateExerciseAttemptsTable.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds three FluentMigrator migrations for the exercise feature schema: `ExerciseSessions`, `ExerciseSessionEntries`, and `ExerciseAttempts` tables
- Extends `Constants.fs` with table/column name literals for all three new tables
- Migrations use `AutoReversingMigration` for safe rollback support

## Test plan

- [ ] CI pipeline builds the migrations project (zero warnings)
- [ ] Migrations apply cleanly against a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)