### PR TITLE
Fix indentation of GetEntryIdsByVocabularyIdTests compile entry

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Wordfolio.Api.DataAccess.Tests.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess.Tests/Wordfolio.Api.DataAccess.Tests.fsproj
@@ -63,7 +63,7 @@
     <Compile Include="ExerciseAttempts/CommitAttemptTests.fs" />
     <Compile Include="ExerciseAttempts/GetAttemptsBySessionTests.fs" />
     <Compile Include="ExerciseAttempts/GetWorstKnownEntriesTests.fs" />
-<Compile Include="Entries/GetEntryIdsByVocabularyIdTests.fs" />
+    <Compile Include="Entries/GetEntryIdsByVocabularyIdTests.fs" />
     <Compile Include="Entries/GetEntryIdsByCollectionIdTests.fs" />
     <Compile Include="Entries/GetEntryIdsByIdsForUserTests.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Restore the missing 4-space indentation on the `GetEntryIdsByVocabularyIdTests.fs` compile entry in `Wordfolio.Api.DataAccess.Tests.fsproj` so it aligns with the surrounding `<Compile Include="..." />` lines.

## Test plan
- [ ] `dotnet build` succeeds (whitespace-only `.fsproj` change, no semantic impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)