### PR TITLE
Add unit tests for ResourceIdEncoder.Decode

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.Tests/Infrastructure/ResourceIdEncoderTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Infrastructure/ResourceIdEncoderTests.fs
@@ -1,80 +1,79 @@
-namespace Wordfolio.Api.Tests.Infrastructure
+module Wordfolio.Api.Tests.Infrastructure.ResourceIdEncoderTests
 
 open Microsoft.Extensions.Options
 
 open Sqids
-
 open Xunit
 
 open Wordfolio.Api.Configuration.SqidsEncoder
 open Wordfolio.Api.Infrastructure.ResourceIdEncoder
 
-module ResourceIdEncoderTests =
+let private testAlphabet =
+    "abcdefghijklmnopqrstuvwxyz"
 
-    let private testAlphabet =
-        "abcdefghijklmnopqrstuvwxyz"
+let private createEncoder() : IResourceIdEncoder =
+    let configuration =
+        { Alphabet = testAlphabet }
 
-    let private createEncoder() : IResourceIdEncoder =
-        let configuration =
-            { Alphabet = testAlphabet }
+    let options = Options.Create(configuration)
+    ResourceIdEncoder(options) :> IResourceIdEncoder
 
-        let options = Options.Create(configuration)
-        ResourceIdEncoder(options) :> IResourceIdEncoder
+[<Fact>]
+let ``valid encoded id returns Some id``() =
+    let encoder = createEncoder()
+    let encoded = encoder.Encode(42)
+    let result = encoder.Decode(encoded)
+    Assert.Equal(Some 42, result)
 
-    [<Fact>]
-    let ``valid encoded id returns Some id``() =
-        let encoder = createEncoder()
-        let encoded = encoder.Encode(42)
-        let result = encoder.Decode(encoded)
-        Assert.Equal(Some 42, result)
+[<Fact>]
+let ``zero is encoded and decoded correctly``() =
+    let encoder = createEncoder()
+    let encoded = encoder.Encode(0)
+    let result = encoder.Decode(encoded)
+    Assert.Equal(Some 0, result)
 
-    [<Fact>]
-    let ``zero is encoded and decoded correctly``() =
-        let encoder = createEncoder()
-        let encoded = encoder.Encode(0)
-        let result = encoder.Decode(encoded)
-        Assert.Equal(Some 0, result)
+[<Fact>]
+let ``multi-id encoding returns None``() =
+    let encoder = createEncoder()
 
-    [<Fact>]
-    let ``multi-id encoding returns None``() =
-        let encoder = createEncoder()
+    let sqids =
+        SqidsEncoder(SqidsOptions(Alphabet = testAlphabet))
 
-        let sqids =
-            SqidsEncoder(SqidsOptions(Alphabet = testAlphabet))
+    let multiIdEncoded =
+        sqids.Encode([| 1; 2 |])
 
-        let multiIdEncoded =
-            sqids.Encode([| 1; 2 |])
+    let result = encoder.Decode(multiIdEncoded)
+    Assert.Equal(None, result)
 
-        let result = encoder.Decode(multiIdEncoded)
-        Assert.Equal(None, result)
+[<Fact>]
+let ``non-canonical encoding returns None``() =
+    let encoder = createEncoder()
+    let result = encoder.Decode("aa")
+    Assert.Equal(None, result)
 
-    [<Fact>]
-    let ``non-canonical encoding returns None``() =
-        let encoder = createEncoder()
-        let result = encoder.Decode("aa")
-        Assert.Equal(None, result)
+[<Fact>]
+let ``overflow to negative returns None without throwing``() =
+    let encoder = createEncoder()
 
-    [<Fact>]
-    let ``overflow to negative returns None without throwing``() =
-        let encoder = createEncoder()
+    let overflowEncoded =
+        String.replicate 32 "z"
 
-        let mutable decodeResult: int option =
-            Some 0
+    let ex =
+        Record.Exception(fun () ->
+            encoder.Decode(overflowEncoded)
+            |> ignore)
 
-        let ex =
-            Record.Exception(fun () -> decodeResult <- encoder.Decode(String.replicate 32 "z"))
+    Assert.Null(ex)
+    Assert.Equal(None, encoder.Decode(overflowEncoded))
 
-        Assert.Null(ex)
-        Assert.Equal(None, decodeResult)
+[<Fact>]
+let ``empty string returns None``() =
+    let encoder = createEncoder()
+    let result = encoder.Decode("")
+    Assert.Equal(None, result)
 
-    [<Fact>]
-    let ``empty string returns None``() =
-        let encoder = createEncoder()
-        let result = encoder.Decode("")
-        Assert.Equal(None, result)
-
-    [<Fact>]
-    let ``out-of-alphabet characters return None``() =
-        let encoder = createEncoder()
-        let result = encoder.Decode("!!!")
-        Assert.Equal(None, result)
+[<Fact>]
+let ``out-of-alphabet characters return None``() =
+    let encoder = createEncoder()
+    let result = encoder.Decode("!!!")
+    Assert.Equal(None, result)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Infrastructure/ResourceIdEncoderTests.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Infrastructure/ResourceIdEncoderTests.fs
@@ -1,0 +1,80 @@
+namespace Wordfolio.Api.Tests.Infrastructure
+
+open Microsoft.Extensions.Options
+
+open Sqids
+
+open Xunit
+
+open Wordfolio.Api.Configuration.SqidsEncoder
+open Wordfolio.Api.Infrastructure.ResourceIdEncoder
+
+module ResourceIdEncoderTests =
+
+    let private testAlphabet =
+        "abcdefghijklmnopqrstuvwxyz"
+
+    let private createEncoder() : IResourceIdEncoder =
+        let configuration =
+            { Alphabet = testAlphabet }
+
+        let options = Options.Create(configuration)
+        ResourceIdEncoder(options) :> IResourceIdEncoder
+
+    [<Fact>]
+    let ``valid encoded id returns Some id``() =
+        let encoder = createEncoder()
+        let encoded = encoder.Encode(42)
+        let result = encoder.Decode(encoded)
+        Assert.Equal(Some 42, result)
+
+    [<Fact>]
+    let ``zero is encoded and decoded correctly``() =
+        let encoder = createEncoder()
+        let encoded = encoder.Encode(0)
+        let result = encoder.Decode(encoded)
+        Assert.Equal(Some 0, result)
+
+    [<Fact>]
+    let ``multi-id encoding returns None``() =
+        let encoder = createEncoder()
+
+        let sqids =
+            SqidsEncoder(SqidsOptions(Alphabet = testAlphabet))
+
+        let multiIdEncoded =
+            sqids.Encode([| 1; 2 |])
+
+        let result = encoder.Decode(multiIdEncoded)
+        Assert.Equal(None, result)
+
+    [<Fact>]
+    let ``non-canonical encoding returns None``() =
+        let encoder = createEncoder()
+        let result = encoder.Decode("aa")
+        Assert.Equal(None, result)
+
+    [<Fact>]
+    let ``overflow to negative returns None without throwing``() =
+        let encoder = createEncoder()
+
+        let mutable decodeResult: int option =
+            Some 0
+
+        let ex =
+            Record.Exception(fun () -> decodeResult <- encoder.Decode(String.replicate 32 "z"))
+
+        Assert.Null(ex)
+        Assert.Equal(None, decodeResult)
+
+    [<Fact>]
+    let ``empty string returns None``() =
+        let encoder = createEncoder()
+        let result = encoder.Decode("")
+        Assert.Equal(None, result)
+
+    [<Fact>]
+    let ``out-of-alphabet characters return None``() =
+        let encoder = createEncoder()
+        let result = encoder.Decode("!!!")
+        Assert.Equal(None, result)

--- a/Wordfolio.Api/Wordfolio.Api.Tests/Wordfolio.Api.Tests.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.Tests/Wordfolio.Api.Tests.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="TestTokenGenerator.fs" />
     <Compile Include="WebApplicationFactory.fs" />
     <Compile Include="Infrastructure\DelimitedStreamProcessorTests.fs" />
+    <Compile Include="Infrastructure\ResourceIdEncoderTests.fs" />
     <Compile Include="Auth/RegisterTests.fs" />
     <Compile Include="Auth/LoginTests.fs" />
     <Compile Include="Auth/RefreshTests.fs" />


### PR DESCRIPTION
## Summary

Adds 7 unit tests for `ResourceIdEncoder.Decode` to fix #270.

## Test Cases

| # | Test | Guard Covered |
|---|------|---------------|
| 1 | Round-trip encode/decode of 42 returns `Some 42` | — |
| 2 | Round-trip encode/decode of 0 returns `Some 0` | — |
| 3 | Multi-id encoding returns `None` | `ids.Count = 1` |
| 4 | Non-canonical encoding (`"aa"` → id 24, canonical is `"ss"`) returns `None` | `sqids.Encode(ids.[0]) = encoded` |
| 5 | Overflow to negative (32 × `"z"`) returns `None` without throwing | `ids.[0] >= 0` |
| 6 | Empty string returns `None` | — |

Each of the three rejection guards in `Decode` is covered by a dedicated test case.