### PR TITLE
Convert plain SQL queries to Dapper.FSharp where feasible

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Entries.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Entries.fs
@@ -180,6 +180,9 @@ let deleteEntryAsync
     }
 
 [<CLIMutable>]
+type private EntryIdRecord = { Id: int; VocabularyId: int }
+
+[<CLIMutable>]
 type private CollectionRecord =
     { Id: int; UserId: int; IsSystem: bool }
 
@@ -254,28 +257,32 @@ let getEntryIdsByVocabularyIdAsync
     (cancellationToken: CancellationToken)
     : Task<int list> =
     task {
-        let sql =
-            """
-            SELECT e."Id"
-            FROM wordfolio."Entries" e
-            INNER JOIN wordfolio."Vocabularies" v ON v."Id" = e."VocabularyId"
-            INNER JOIN wordfolio."Collections" c ON c."Id" = v."CollectionId"
-            WHERE e."VocabularyId" = @vocabularyId
-              AND c."UserId" = @userId;
-            """
+        let entriesTable =
+            table'<EntryIdRecord> Schema.EntriesTable.Name
+            |> inSchema Schema.Name
 
-        let commandDefinition =
-            CommandDefinition(
-                commandText = sql,
-                parameters =
-                    {| vocabularyId = vocabularyId
-                       userId = userId |},
-                transaction = transaction,
-                cancellationToken = cancellationToken
-            )
+        let vocabulariesTable =
+            table'<VocabularyRecord> Schema.VocabulariesTable.Name
+            |> inSchema Schema.Name
 
-        let! ids = connection.QueryAsync<int>(commandDefinition)
-        return ids |> Seq.toList
+        let collectionsTable =
+            table'<CollectionRecord> Schema.CollectionsTable.Name
+            |> inSchema Schema.Name
+
+        let! results =
+            select {
+                for e in entriesTable do
+                    innerJoin v in vocabulariesTable on (e.VocabularyId = v.Id)
+                    innerJoin c in collectionsTable on (v.CollectionId = c.Id)
+
+                    where(
+                        e.VocabularyId = vocabularyId
+                        && c.UserId = userId
+                    )
+            }
+            |> selectAsync<EntryIdRecord> connection transaction cancellationToken
+
+        return results |> List.map(fun r -> r.Id)
     }
 
 let getEntryIdsByCollectionIdAsync
@@ -286,28 +293,32 @@ let getEntryIdsByCollectionIdAsync
     (cancellationToken: CancellationToken)
     : Task<int list> =
     task {
-        let sql =
-            """
-            SELECT e."Id"
-            FROM wordfolio."Entries" e
-            INNER JOIN wordfolio."Vocabularies" v ON v."Id" = e."VocabularyId"
-            INNER JOIN wordfolio."Collections" c ON c."Id" = v."CollectionId"
-            WHERE v."CollectionId" = @collectionId
-              AND c."UserId" = @userId;
-            """
+        let entriesTable =
+            table'<EntryIdRecord> Schema.EntriesTable.Name
+            |> inSchema Schema.Name
 
-        let commandDefinition =
-            CommandDefinition(
-                commandText = sql,
-                parameters =
-                    {| collectionId = collectionId
-                       userId = userId |},
-                transaction = transaction,
-                cancellationToken = cancellationToken
-            )
+        let vocabulariesTable =
+            table'<VocabularyRecord> Schema.VocabulariesTable.Name
+            |> inSchema Schema.Name
 
-        let! ids = connection.QueryAsync<int>(commandDefinition)
-        return ids |> Seq.toList
+        let collectionsTable =
+            table'<CollectionRecord> Schema.CollectionsTable.Name
+            |> inSchema Schema.Name
+
+        let! results =
+            select {
+                for e in entriesTable do
+                    innerJoin v in vocabulariesTable on (e.VocabularyId = v.Id)
+                    innerJoin c in collectionsTable on (v.CollectionId = c.Id)
+
+                    where(
+                        v.CollectionId = collectionId
+                        && c.UserId = userId
+                    )
+            }
+            |> selectAsync<EntryIdRecord> connection transaction cancellationToken
+
+        return results |> List.map(fun r -> r.Id)
     }
 
 let getEntryIdsByUserIdAsync
@@ -317,25 +328,28 @@ let getEntryIdsByUserIdAsync
     (cancellationToken: CancellationToken)
     : Task<int list> =
     task {
-        let sql =
-            """
-            SELECT e."Id"
-            FROM wordfolio."Entries" e
-            INNER JOIN wordfolio."Vocabularies" v ON v."Id" = e."VocabularyId"
-            INNER JOIN wordfolio."Collections" c ON c."Id" = v."CollectionId"
-            WHERE c."UserId" = @userId;
-            """
+        let entriesTable =
+            table'<EntryIdRecord> Schema.EntriesTable.Name
+            |> inSchema Schema.Name
 
-        let commandDefinition =
-            CommandDefinition(
-                commandText = sql,
-                parameters = {| userId = userId |},
-                transaction = transaction,
-                cancellationToken = cancellationToken
-            )
+        let vocabulariesTable =
+            table'<VocabularyRecord> Schema.VocabulariesTable.Name
+            |> inSchema Schema.Name
 
-        let! ids = connection.QueryAsync<int>(commandDefinition)
-        return ids |> Seq.toList
+        let collectionsTable =
+            table'<CollectionRecord> Schema.CollectionsTable.Name
+            |> inSchema Schema.Name
+
+        let! results =
+            select {
+                for e in entriesTable do
+                    innerJoin v in vocabulariesTable on (e.VocabularyId = v.Id)
+                    innerJoin c in collectionsTable on (v.CollectionId = c.Id)
+                    where(c.UserId = userId)
+            }
+            |> selectAsync<EntryIdRecord> connection transaction cancellationToken
+
+        return results |> List.map(fun r -> r.Id)
     }
 
 let getEntryIdsByIdsForUserAsync
@@ -349,26 +363,30 @@ let getEntryIdsByIdsForUserAsync
         if requestedIds.IsEmpty then
             return []
         else
-            let sql =
-                """
-                SELECT e."Id"
-                FROM wordfolio."Entries" e
-                INNER JOIN wordfolio."Vocabularies" v ON v."Id" = e."VocabularyId"
-                INNER JOIN wordfolio."Collections" c ON c."Id" = v."CollectionId"
-                WHERE e."Id" = ANY(@requestedIds)
-                  AND c."UserId" = @userId;
-                """
+            let entriesTable =
+                table'<EntryIdRecord> Schema.EntriesTable.Name
+                |> inSchema Schema.Name
 
-            let commandDefinition =
-                CommandDefinition(
-                    commandText = sql,
-                    parameters =
-                        {| requestedIds = requestedIds |> List.toArray
-                           userId = userId |},
-                    transaction = transaction,
-                    cancellationToken = cancellationToken
-                )
+            let vocabulariesTable =
+                table'<VocabularyRecord> Schema.VocabulariesTable.Name
+                |> inSchema Schema.Name
 
-            let! ids = connection.QueryAsync<int>(commandDefinition)
-            return ids |> Seq.toList
+            let collectionsTable =
+                table'<CollectionRecord> Schema.CollectionsTable.Name
+                |> inSchema Schema.Name
+
+            let! results =
+                select {
+                    for e in entriesTable do
+                        innerJoin v in vocabulariesTable on (e.VocabularyId = v.Id)
+                        innerJoin c in collectionsTable on (v.CollectionId = c.Id)
+
+                        where(
+                            isIn e.Id requestedIds
+                            && c.UserId = userId
+                        )
+                }
+                |> selectAsync<EntryIdRecord> connection transaction cancellationToken
+
+            return results |> List.map(fun r -> r.Id)
     }

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/EntriesHierarchy.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/EntriesHierarchy.fs
@@ -402,25 +402,18 @@ let getEntriesByIdsWithHierarchyAsync
         if entryIds.IsEmpty then
             return []
         else
-            let sql =
-                """
-                SELECT "Id", "VocabularyId", "EntryText", "CreatedAt", "UpdatedAt"
-                FROM wordfolio."Entries"
-                WHERE "Id" = ANY(@entryIds);
-                """
+            let entriesTable =
+                table'<EntryRecord> Schema.EntriesTable.Name
+                |> inSchema Schema.Name
 
-            let commandDefinition =
-                CommandDefinition(
-                    commandText = sql,
-                    parameters = {| entryIds = entryIds |> List.toArray |},
-                    transaction = transaction,
-                    cancellationToken = cancellationToken
-                )
+            let! entries =
+                select {
+                    for e in entriesTable do
+                        where(isIn e.Id entryIds)
+                }
+                |> selectAsync<EntryRecord> connection transaction cancellationToken
 
-            let! entries = connection.QueryAsync<EntryRecord>(commandDefinition)
-            let entryList = entries |> Seq.toList
-
-            if entryList.IsEmpty then
+            if entries.IsEmpty then
                 return []
             else
                 let! definitions = getDefinitionRecordsByEntryIdsAsync entryIds connection transaction cancellationToken
@@ -445,7 +438,7 @@ let getEntriesByIdsWithHierarchyAsync
                 let examples =
                     definitionExamples @ translationExamples
 
-                return assembleEntriesWithHierarchy entryList definitions translations examples
+                return assembleEntriesWithHierarchy entries definitions translations examples
     }
 
 let getEntriesHierarchyByVocabularyIdAsync

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseAttempts.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseAttempts.fs
@@ -136,28 +136,19 @@ let getAttemptsBySessionAsync
     (cancellationToken: CancellationToken)
     : Task<ExerciseAttempt list> =
     task {
-        let sql =
-            """
-            SELECT "Id", "UserId", "SessionId", "EntryId", "ExerciseType", "PromptData", "PromptSchemaVersion", "RawAnswer", "IsCorrect", "AttemptedAt"
-            FROM wordfolio."ExerciseAttempts"
-            WHERE "SessionId" = @sessionId
-            ORDER BY "Id";
-            """
+        let attemptsTable =
+            table'<ExerciseAttemptRecord> Schema.ExerciseAttemptsTable.Name
+            |> inSchema Schema.Name
 
-        let commandDefinition =
-            CommandDefinition(
-                commandText = sql,
-                parameters = {| sessionId = sessionId |},
-                transaction = transaction,
-                cancellationToken = cancellationToken
-            )
+        let! results =
+            select {
+                for a in attemptsTable do
+                    where(a.SessionId = Some sessionId)
+                    orderBy a.Id
+            }
+            |> selectAsync<ExerciseAttemptRecord> connection transaction cancellationToken
 
-        let! results = connection.QueryAsync<ExerciseAttemptRecord>(commandDefinition)
-
-        return
-            results
-            |> Seq.map fromRecord
-            |> Seq.toList
+        return results |> List.map fromRecord
     }
 
 let getWorstKnownEntriesAsync

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseSessions.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseSessions.fs
@@ -187,26 +187,19 @@ let getSessionEntriesAsync
     (cancellationToken: CancellationToken)
     : Task<ExerciseSessionEntry list> =
     task {
-        let sql =
-            """
-            SELECT "Id", "SessionId", "EntryId", "DisplayOrder", "PromptData", "PromptSchemaVersion"
-            FROM wordfolio."ExerciseSessionEntries"
-            WHERE "SessionId" = @sessionId
-            ORDER BY "DisplayOrder";
-            """
+        let sessionEntriesTable =
+            table'<ExerciseSessionEntryRecord> Schema.ExerciseSessionEntriesTable.Name
+            |> inSchema Schema.Name
 
-        let commandDefinition =
-            CommandDefinition(
-                commandText = sql,
-                parameters = {| sessionId = sessionId |},
-                transaction = transaction,
-                cancellationToken = cancellationToken
-            )
-
-        let! results = connection.QueryAsync<ExerciseSessionEntryRecord>(commandDefinition)
+        let! results =
+            select {
+                for e in sessionEntriesTable do
+                    where(e.SessionId = sessionId)
+                    orderBy e.DisplayOrder
+            }
+            |> selectAsync<ExerciseSessionEntryRecord> connection transaction cancellationToken
 
         return
             results
-            |> Seq.map fromSessionEntryRecord
-            |> Seq.toList
+            |> List.map fromSessionEntryRecord
     }


### PR DESCRIPTION
## Summary

Converts the plain SQL data access functions introduced in commit `3a0b0b5` to Dapper.FSharp CE syntax where technically feasible, improving type safety and consistency with existing codebase patterns.

## Converted to Dapper.FSharp (7 functions)

| Function | File |
|---|---|
| `getEntryIdsByVocabularyIdAsync` | `Entries.fs` |
| `getEntryIdsByCollectionIdAsync` | `Entries.fs` |
| `getEntryIdsByUserIdAsync` | `Entries.fs` |
| `getEntryIdsByIdsForUserAsync` | `Entries.fs` |
| `getEntriesByIdsWithHierarchyAsync` (initial fetch only) | `EntriesHierarchy.fs` |
| `getAttemptsBySessionAsync` | `ExerciseAttempts.fs` |
| `getSessionEntriesAsync` | `ExerciseSessions.fs` |

## Kept as plain SQL (5 functions — justified)

| Function | Reason |
|---|---|
| `getEntryRecordsByVocabularyIdAsync` | `ORDER BY … NULLS LAST` not supported in Dapper.FSharp |
| `getExampleRecordsByDefinitionIdsAsync` | `isIn` with `int option` field not serializable |
| `getExampleRecordsByTranslationIdsAsync` | `isIn` with `int option` field not serializable |
| `commitAttemptAsync` | `INSERT … ON CONFLICT … DO NOTHING RETURNING` not expressible |
| `getWorstKnownEntriesAsync` | CTEs + window functions beyond Dapper.FSharp scope |

## Key design decisions

- **Minimal projection record**: Added `EntryIdRecord = { Id: int; VocabularyId: int }` for the four entry ID join queries, following the existing codebase convention of minimal projection records (e.g. `CollectionRecord` in `Vocabularies.fs`).
- **`commitAttemptAsync` kept whole**: The INSERT and fallback SELECT are tightly coupled; splitting them across paradigms would reduce coherence without meaningful benefit.