### PR TITLE
fix: resolve FS3511 warnings and enable TreatWarningsAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Entries/Handlers.fs
@@ -3,6 +3,7 @@ module Wordfolio.Api.Api.Entries.Handlers
 open System
 open System.Security.Claims
 open System.Threading
+open System.Threading.Tasks
 
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
@@ -75,6 +76,53 @@ let private toMoveErrorResponse(error: MoveEntryError) : IResult =
     match error with
     | MoveEntryError.EntryNotFound _ -> Results.NotFound()
     | MoveEntryError.VocabularyNotFoundOrAccessDenied _ -> Results.NotFound({| error = "Vocabulary not found" |})
+
+let private moveEntryHandler
+    (collectionId: string)
+    (vocabularyId: string)
+    (id: string)
+    (request: MoveEntryRequest)
+    (user: ClaimsPrincipal)
+    (encoder: IResourceIdEncoder)
+    (dataSource: NpgsqlDataSource)
+    (cancellationToken: CancellationToken)
+    : Task<IResult> =
+    match getUserId user with
+    | None -> Task.FromResult(Results.Unauthorized())
+    | Some userId ->
+        let decodedTargetVocabularyId =
+            request.VocabularyId
+            |> Option.bind encoder.Decode
+
+        let targetVocabularyIdValid =
+            request.VocabularyId.IsNone
+            || decodedTargetVocabularyId.IsSome
+
+        match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
+        | None -> Task.FromResult(Results.NotFound())
+        | _ when not targetVocabularyIdValid -> Task.FromResult(Results.NotFound())
+        | Some(decodedCollectionId, decodedVocabularyId, decodedId) ->
+            let env =
+                TransactionalEnv(dataSource, cancellationToken)
+
+            let moveParameters =
+                { UserId = UserId userId
+                  CollectionId = CollectionId decodedCollectionId
+                  VocabularyId = VocabularyId decodedVocabularyId
+                  EntryId = EntryId decodedId
+                  TargetVocabularyId =
+                    decodedTargetVocabularyId
+                    |> Option.map VocabularyId
+                  UpdatedAt = DateTimeOffset.UtcNow }
+
+            task {
+                let! result = move env moveParameters
+
+                return
+                    match result with
+                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
+                    | Error error -> toMoveErrorResponse error
+            }
 
 let mapEntriesEndpoints(group: RouteGroupBuilder) =
     group
@@ -287,42 +335,7 @@ let mapEntriesEndpoints(group: RouteGroupBuilder) =
             UrlTokens.ById + "/move",
             Func<string, string, string, MoveEntryRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun collectionId vocabularyId id request user encoder dataSource cancellationToken ->
-                    task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
-                            let decodedTargetVocabularyId =
-                                request.VocabularyId
-                                |> Option.bind encoder.Decode
-
-                            let targetVocabularyIdValid =
-                                request.VocabularyId.IsNone
-                                || decodedTargetVocabularyId.IsSome
-
-                            match ResourceIdsHelper.Decode(encoder, collectionId, vocabularyId, id) with
-                            | None -> return Results.NotFound()
-                            | _ when not targetVocabularyIdValid -> return Results.NotFound()
-                            | Some(collectionId, vocabularyId, id) ->
-                                let env =
-                                    TransactionalEnv(dataSource, cancellationToken)
-
-                                let! result =
-                                    move
-                                        env
-                                        { UserId = UserId userId
-                                          CollectionId = CollectionId collectionId
-                                          VocabularyId = VocabularyId vocabularyId
-                                          EntryId = EntryId id
-                                          TargetVocabularyId =
-                                            decodedTargetVocabularyId
-                                            |> Option.map VocabularyId
-                                          UpdatedAt = DateTimeOffset.UtcNow }
-
-                                return
-                                    match result with
-                                    | Ok entry -> Results.Ok(toEntryResponse encoder entry)
-                                    | Error error -> toMoveErrorResponse error
-                    })
+                    moveEntryHandler collectionId vocabularyId id request user encoder dataSource cancellationToken)
         )
         .Produces<EntryResponse>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
@@ -3,6 +3,7 @@ module Wordfolio.Api.Api.Exercises.Handlers
 open System
 open System.Security.Claims
 open System.Threading
+open System.Threading.Tasks
 
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
@@ -44,58 +45,66 @@ let private toSubmitAttemptErrorResponse(error: SubmitAttemptError) : IResult =
     | SubmitAttemptError.ConflictingAttempt -> Results.Conflict({| error = "A conflicting attempt already exists" |})
     | SubmitAttemptError.EvaluateError _ -> Results.StatusCode(StatusCodes.Status500InternalServerError)
 
+let private createSessionHandler
+    (request: CreateSessionRequest)
+    (user: ClaimsPrincipal)
+    (encoder: IResourceIdEncoder)
+    (dataSource: NpgsqlDataSource)
+    (cancellationToken: CancellationToken)
+    : Task<IResult> =
+    match getUserId user with
+    | None -> Task.FromResult(Results.Unauthorized())
+    | Some userId ->
+        if
+            isNull(box request)
+            || isNull(box request.Selector)
+        then
+            Task.FromResult(Results.BadRequest({| error = "Invalid request body" |}))
+        else
+            match tryMapSelector encoder request.Selector with
+            | Error message -> Task.FromResult(Results.BadRequest({| error = message |}))
+            | Ok selector ->
+                let limitError =
+                    match selector with
+                    | ExplicitEntries entries when entries.Length > Limits.MaxSessionEntries ->
+                        Some $"Cannot specify more than {Limits.MaxSessionEntries} entries"
+                    | WorstKnown(_, count) when count <= 0 -> Some "Count must be positive"
+                    | WorstKnown(_, count) when count > Limits.MaxSessionEntries ->
+                        Some $"Count cannot exceed {Limits.MaxSessionEntries}"
+                    | _ -> None
+
+                match limitError with
+                | Some message -> Task.FromResult(Results.BadRequest({| error = message |}))
+                | None ->
+                    let parameters: CreateSessionParameters =
+                        { UserId = UserId userId
+                          ExerciseType = toExerciseTypeDomain request.ExerciseType
+                          Selector = selector
+                          CreatedAt = DateTimeOffset.UtcNow }
+
+                    let env =
+                        TransactionalEnv(dataSource, cancellationToken)
+
+                    task {
+                        let! result = runInTransaction env (fun appEnv -> createSession appEnv parameters)
+
+                        return
+                            match result with
+                            | Ok bundle ->
+                                let response =
+                                    toSessionBundleResponse encoder bundle
+
+                                Results.Created(ExerciseUrls.sessionById response.SessionId, response)
+                            | Error error -> toCreateSessionErrorResponse error
+                    }
+
 let mapExercisesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
             UrlTokens.Root,
             Func<CreateSessionRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun request user encoder dataSource cancellationToken ->
-                    task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
-                            if
-                                isNull(box request)
-                                || isNull(box request.Selector)
-                            then
-                                return Results.BadRequest({| error = "Invalid request body" |})
-                            else
-                                match tryMapSelector encoder request.Selector with
-                                | Error message -> return Results.BadRequest({| error = message |})
-                                | Ok selector ->
-                                    let limitError =
-                                        match selector with
-                                        | ExplicitEntries entries when entries.Length > Limits.MaxSessionEntries ->
-                                            Some $"Cannot specify more than {Limits.MaxSessionEntries} entries"
-                                        | WorstKnown(_, count) when count <= 0 -> Some "Count must be positive"
-                                        | WorstKnown(_, count) when count > Limits.MaxSessionEntries ->
-                                            Some $"Count cannot exceed {Limits.MaxSessionEntries}"
-                                        | _ -> None
-
-                                    match limitError with
-                                    | Some message -> return Results.BadRequest({| error = message |})
-                                    | None ->
-                                        let parameters: CreateSessionParameters =
-                                            { UserId = UserId userId
-                                              ExerciseType = toExerciseTypeDomain request.ExerciseType
-                                              Selector = selector
-                                              CreatedAt = DateTimeOffset.UtcNow }
-
-                                        let env =
-                                            TransactionalEnv(dataSource, cancellationToken)
-
-                                        let! result =
-                                            runInTransaction env (fun appEnv -> createSession appEnv parameters)
-
-                                        return
-                                            match result with
-                                            | Ok bundle ->
-                                                let response =
-                                                    toSessionBundleResponse encoder bundle
-
-                                                Results.Created(ExerciseUrls.sessionById response.SessionId, response)
-                                            | Error error -> toCreateSessionErrorResponse error
-                    })
+                    createSessionHandler request user encoder dataSource cancellationToken)
         )
         .Produces<SessionBundleResponse>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status400BadRequest)


### PR DESCRIPTION
## Summary

Fixes #264.

Resolves two `FS3511: This state machine is not statically compilable` warnings in the API layer and enables `TreatWarningsAsErrors` across all backend projects to prevent future regressions.

## Changes

### FS3511 fixes

The F# compiler cannot statically compile a `task { }` computation expression inside a wide-closure `Func<...>` lambda. The fix extracts the async body into a named private function (where the compiler *can* produce a static state machine), then delegates from a thin lambda that only has explicit named parameters.

- **`Api/Exercises/Handlers.fs`**: Same extraction for the Create Session handler into `createSessionHandler`.

The `MapPost` registrations keep the explicit `fun collectionId vocabularyId ...` lambda wrapper so that ASP.NET Core Minimal APIs correctly resolve route parameter names for binding and OpenAPI generation.

### TreatWarningsAsErrors

Added `Directory.Build.props` at the solution root:

```xml
<Project>

  <PropertyGroup>
    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
  </PropertyGroup>

</Project>
```

This propagates `/warnaserror` to all F# and C# compiler invocations via MSBuild inheritance. `NU1902` (NuGet vulnerability audit for OpenTelemetry.Api) is explicitly kept as a warning since it is a pre-existing advisory unrelated to compiler warnings.

## Verification

- `dotnet build --configuration Release --no-incremental` — zero FS3511 warnings, zero errors
- `dotnet test --configuration Release` — all 666 tests pass (205 data access + 228 domain + 233 integration)
- No behavioral change to any endpoint