### PR TITLE
Unpin .NET SDK version and upgrade Dapper.FSharp to 4.10.0

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -10,6 +10,7 @@ on:
       - 'Wordfolio.MigrationRunner/**'
       - 'Wordfolio.ServiceDefaults/**'
       - '*.sln'
+      - 'global.json'
       - 'fantomas-config.json'
       - '*.props'
       - '*.targets'

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
+  </ItemGroup>
+
+</Project>

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Wordfolio.Api.DataAccess.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Wordfolio.Api.DataAccess.fsproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Npgsql" Version="13.1.3" />
-    <PackageReference Include="Dapper.FSharp" Version="4.9.0" />
+    <PackageReference Include="Dapper.FSharp" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio.Api.Tests.Utils.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.Tests.Utils/Wordfolio.Api.Tests.Utils.fsproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.6.0" />
     <PackageReference Include="Testcontainers.XunitV3" Version="4.6.0" />
     <PackageReference Include="Npgsql" Version="10.0.1" />
-    <PackageReference Include="Dapper.FSharp" Version="4.9.0" />
+    <PackageReference Include="Dapper.FSharp" Version="4.10.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.0.1" />
     <PackageReference Include="FluentMigrator.Runner" Version="7.1.0" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="7.1.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Closes #266

Dapper.FSharp 4.10.0 ships support for F# 10 BlockExpression in LINQ visitors for joined queries (Dzoukr/Dapper.FSharp#111), removing the need to pin the .NET SDK to a specific feature band.

Changes:
- Upgrade Dapper.FSharp from 4.9.0 to 4.10.0
- Add `Directory.Build.targets` to update FSharp.Core to 10.1.201 globally (required by Dapper.FSharp 4.10.0)
- Change `global.json` `rollForward` from `latestPatch` to `latestFeature`
- Add `global.json` to backend CI path triggers