### PR TITLE
Use F# option instead of Nullable and box-null checks in ExerciseAttempts

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseAttempts.fs
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/ExerciseAttempts.fs
@@ -97,11 +97,11 @@ let commitAttemptAsync
                 cancellationToken = cancellationToken
             )
 
-        let! insertedId = connection.QueryFirstOrDefaultAsync<Nullable<int>>(insertCommand)
+        let! insertedId = connection.QueryFirstOrDefaultAsync<int option>(insertCommand)
 
-        if insertedId.HasValue then
-            return AttemptInserted insertedId.Value
-        else
+        match insertedId with
+        | Some id -> return AttemptInserted id
+        | None ->
             let readSql =
                 """
                 SELECT "Id", "UserId", "SessionId", "EntryId", "ExerciseType", "PromptData", "PromptSchemaVersion", "RawAnswer", "IsCorrect", "AttemptedAt"
@@ -121,12 +121,13 @@ let commitAttemptAsync
 
             let! existing = connection.QueryFirstOrDefaultAsync<ExerciseAttemptRecord>(readCommand)
 
-            if box existing = null then
-                return ConflictingReplay
-            else if existing.RawAnswer = parameters.RawAnswer then
-                return IdempotentReplay existing.IsCorrect
-            else
-                return ConflictingReplay
+            match existing |> Option.ofObj with
+            | None -> return ConflictingReplay
+            | Some record ->
+                if record.RawAnswer = parameters.RawAnswer then
+                    return IdempotentReplay record.IsCorrect
+                else
+                    return ConflictingReplay
     }
 
 let getAttemptsBySessionAsync


### PR DESCRIPTION
## Summary

Replace C#-style null handling with idiomatic F# option types in `commitAttemptAsync`.

`OptionTypes.register()` from Dapper.FSharp is called globally (in `Program.fs` at startup and in `BaseDatabaseTestFixture` for tests), so the type handler is active everywhere and F# `option` types are safe to use with Dapper queries.

## Changes

- `QueryFirstOrDefaultAsync<Nullable<int>>` → `QueryFirstOrDefaultAsync<int option>` with pattern matching
- `if box existing = null then` → `match existing |> Option.ofObj with` for the follow-up record lookup

Both changes are in `Wordfolio.Api.DataAccess/ExerciseAttempts.fs`.