### PR TITLE
fix: resolve NU1902 vulnerable package warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/Wordfolio.Api/Wordfolio.Api.DataAccess/Wordfolio.Api.DataAccess.fsproj
+++ b/Wordfolio.Api/Wordfolio.Api.DataAccess/Wordfolio.Api.DataAccess.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql" Version="13.1.3" />
+    <PackageReference Include="Aspire.Npgsql" Version="13.2.4" />
     <PackageReference Include="Dapper.FSharp" Version="4.10.0" />
   </ItemGroup>
 

--- a/Wordfolio.Api/Wordfolio.Api.Identity/Wordfolio.Api.Identity.csproj
+++ b/Wordfolio.Api/Wordfolio.Api.Identity/Wordfolio.Api.Identity.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.3" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
   </ItemGroup>
 

--- a/Wordfolio.MigrationRunner/Wordfolio.MigrationRunner.fsproj
+++ b/Wordfolio.MigrationRunner/Wordfolio.MigrationRunner.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.3" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.2.4" />
     <PackageReference Include="FluentMigrator.Runner" Version="7.1.0" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="7.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">

--- a/Wordfolio.ServiceDefaults/Wordfolio.ServiceDefaults.fsproj
+++ b/Wordfolio.ServiceDefaults/Wordfolio.ServiceDefaults.fsproj
@@ -11,11 +11,11 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Resolves #277 — eliminates all NU1902 vulnerable package warnings and removes the suppression.

## Changes

### Direct OTel fix
Updated OpenTelemetry packages in `Wordfolio.ServiceDefaults` which carried a known vulnerability in the `System.Net.Http` transitive dependency:
- `OpenTelemetry.Exporter.OpenTelemetryProtocol`: 1.12.0 → 1.15.3
- `OpenTelemetry.Extensions.Hosting`: 1.12.0 → 1.15.3
- `OpenTelemetry.Instrumentation.AspNetCore`: 1.12.0 → 1.15.2
- `OpenTelemetry.Instrumentation.Http`: 1.12.0 → 1.15.1
- `OpenTelemetry.Instrumentation.Runtime`: 1.12.0 → 1.15.1

### Aspire transitive fix
Updated `Aspire.Npgsql` / `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` from 13.1.3 → 13.2.4 in:
- `Wordfolio.Api.DataAccess`
- `Wordfolio.Api.Identity`
- `Wordfolio.MigrationRunner`

The Aspire 13.2.4 package resolves the vulnerable transitive dependency that 13.1.3 pulled in.

### Suppression removal
Removed `<WarningsNotAsErrors>NU1902</WarningsNotAsErrors>` from `Directory.Build.props`. Both upgrade paths (OTel direct + Aspire transitive) are sufficient to eliminate all NU1902 warnings, confirmed by `dotnet list package --vulnerable --include-transitive` showing no vulnerable packages across all 13 projects.

## Validation

- `dotnet restore` — clean, no errors
- `dotnet list package --vulnerable --include-transitive` — **0 vulnerable packages** across all projects
- `dotnet build` — **0 warnings, 0 errors**
- `dotnet fantomas --check .` — passed
- `dotnet format --verify-no-changes` — passed