### PR TITLE
Replace exercise null boxing checks

### DIFF
--- a/Wordfolio.Api/Wordfolio.Api.Domain/Exercises/ExerciseTypes.fs
+++ b/Wordfolio.Api/Wordfolio.Api.Domain/Exercises/ExerciseTypes.fs
@@ -20,13 +20,8 @@ module MultipleChoice =
 
     let private tryDeserialize(json: string) : PromptDto option =
         try
-            let result =
-                JsonSerializer.Deserialize<PromptDto>(json)
-
-            if isNull(box result) then
-                None
-            else
-                Some result
+            JsonSerializer.Deserialize<PromptDto>(json)
+            |> Option.ofObj
         with :? JsonException ->
             None
 
@@ -89,11 +84,13 @@ module MultipleChoice =
 
             match tryDeserialize json with
             | None -> Error EvaluateError.MalformedPromptData
-            | Some dto when isNull dto.correctOptionId -> Error EvaluateError.MalformedPromptData
             | Some dto ->
                 let (RawAnswer answer) = rawAnswer
 
-                Ok(String.Equals(dto.correctOptionId.Trim(), answer.Trim(), StringComparison.OrdinalIgnoreCase))
+                match dto.correctOptionId |> Option.ofObj with
+                | None -> Error EvaluateError.MalformedPromptData
+                | Some correctOptionId ->
+                    Ok(String.Equals(correctOptionId.Trim(), answer.Trim(), StringComparison.OrdinalIgnoreCase))
 
 module Translation =
     [<CLIMutable>]
@@ -103,13 +100,8 @@ module Translation =
 
     let private tryDeserialize(json: string) : PromptDto option =
         try
-            let result =
-                JsonSerializer.Deserialize<PromptDto>(json)
-
-            if isNull(box result) then
-                None
-            else
-                Some result
+            JsonSerializer.Deserialize<PromptDto>(json)
+            |> Option.ofObj
         with :? JsonException ->
             None
 
@@ -136,15 +128,17 @@ module Translation =
 
             match tryDeserialize json with
             | None -> Error EvaluateError.MalformedPromptData
-            | Some dto when isNull dto.acceptedTranslations -> Error EvaluateError.MalformedPromptData
             | Some dto ->
                 let (RawAnswer answer) = rawAnswer
 
-                let normalizedAnswer =
-                    answer.Trim().ToLowerInvariant()
+                match dto.acceptedTranslations |> Option.ofObj with
+                | None -> Error EvaluateError.MalformedPromptData
+                | Some acceptedTranslations ->
+                    let normalizedAnswer =
+                        answer.Trim().ToLowerInvariant()
 
-                let isCorrect =
-                    dto.acceptedTranslations
-                    |> Array.exists(fun t -> t.Trim().ToLowerInvariant() = normalizedAnswer)
+                    let isCorrect =
+                        acceptedTranslations
+                        |> Array.exists(fun t -> t.Trim().ToLowerInvariant() = normalizedAnswer)
 
-                Ok isCorrect
+                    Ok isCorrect

--- a/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
@@ -48,6 +48,13 @@ let private toSubmitAttemptErrorResponse(error: SubmitAttemptError) : IResult =
 let private invalidRequestBody() : IResult =
     Results.BadRequest({| error = "Invalid request body" |})
 
+let private tryGetRawAnswer(request: SubmitAttemptRequest) : string option =
+    request
+    |> Option.ofObj
+    |> Option.bind(fun submitAttemptRequest ->
+        submitAttemptRequest.RawAnswer
+        |> Option.ofObj)
+
 let private createSessionHandler
     (request: CreateSessionRequest)
     (user: ClaimsPrincipal)
@@ -101,6 +108,53 @@ let private createSessionHandler
                                 | Error error -> toCreateSessionErrorResponse error
                         }
 
+let private submitAttemptHandler
+    (sessionId: string)
+    (entryId: string)
+    (request: SubmitAttemptRequest)
+    (user: ClaimsPrincipal)
+    (encoder: IResourceIdEncoder)
+    (dataSource: NpgsqlDataSource)
+    (cancellationToken: CancellationToken)
+    : Task<IResult> =
+    match getUserId user with
+    | None -> Task.FromResult(Results.Unauthorized())
+    | Some userId ->
+        match encoder.Decode(sessionId), encoder.Decode(entryId), tryGetRawAnswer request with
+        | None, _, _
+        | _, None, _ -> Task.FromResult(Results.NotFound())
+        | _, _, None -> Task.FromResult(invalidRequestBody())
+        | Some decodedSessionId, Some decodedEntryId, Some rawAnswer ->
+            let env =
+                TransactionalEnv(dataSource, cancellationToken)
+
+            task {
+                let! result =
+                    runInTransaction env (fun appEnv ->
+                        submitAttempt
+                            appEnv
+                            (UserId userId)
+                            (ExerciseSessionId decodedSessionId)
+                            (EntryId decodedEntryId)
+                            (RawAnswer rawAnswer)
+                            DateTimeOffset.UtcNow)
+
+                return
+                    match result with
+                    | Ok(Inserted inserted) ->
+                        let response: SubmitAttemptResponse =
+                            { IsCorrect = inserted.IsCorrect }
+
+                        Results.Created(ExerciseUrls.sessionById sessionId, response)
+                    | Ok(IdempotentReplay replay) ->
+                        let response: SubmitAttemptResponse =
+                            { IsCorrect = replay.IsCorrect }
+
+                        Results.Ok(response)
+                    | Ok ConflictingReplay -> toSubmitAttemptErrorResponse SubmitAttemptError.ConflictingAttempt
+                    | Error error -> toSubmitAttemptErrorResponse error
+            }
+
 let mapExercisesEndpoints(group: RouteGroupBuilder) =
     group
         .MapPost(
@@ -150,49 +204,7 @@ let mapExercisesEndpoints(group: RouteGroupBuilder) =
             ExerciseUrls.EntryAttempts,
             Func<string, string, SubmitAttemptRequest, ClaimsPrincipal, IResourceIdEncoder, NpgsqlDataSource, CancellationToken, _>
                 (fun sessionId entryId request user encoder dataSource cancellationToken ->
-                    task {
-                        match getUserId user with
-                        | None -> return Results.Unauthorized()
-                        | Some userId ->
-                            match encoder.Decode(sessionId), encoder.Decode(entryId) with
-                            | None, _
-                            | _, None -> return Results.NotFound()
-                            | Some decodedSessionId, Some decodedEntryId ->
-                                match request |> Option.ofObj with
-                                | None -> return invalidRequestBody()
-                                | Some request ->
-                                    match request.RawAnswer |> Option.ofObj with
-                                    | None -> return invalidRequestBody()
-                                    | Some rawAnswer ->
-                                        let env =
-                                            TransactionalEnv(dataSource, cancellationToken)
-
-                                        let! result =
-                                            runInTransaction env (fun appEnv ->
-                                                submitAttempt
-                                                    appEnv
-                                                    (UserId userId)
-                                                    (ExerciseSessionId decodedSessionId)
-                                                    (EntryId decodedEntryId)
-                                                    (RawAnswer rawAnswer)
-                                                    DateTimeOffset.UtcNow)
-
-                                        return
-                                            match result with
-                                            | Ok(Inserted inserted) ->
-                                                let response: SubmitAttemptResponse =
-                                                    { IsCorrect = inserted.IsCorrect }
-
-                                                Results.Created(ExerciseUrls.sessionById sessionId, response)
-                                            | Ok(IdempotentReplay replay) ->
-                                                let response: SubmitAttemptResponse =
-                                                    { IsCorrect = replay.IsCorrect }
-
-                                                Results.Ok(response)
-                                            | Ok ConflictingReplay ->
-                                                toSubmitAttemptErrorResponse SubmitAttemptError.ConflictingAttempt
-                                            | Error error -> toSubmitAttemptErrorResponse error
-                    })
+                    submitAttemptHandler sessionId entryId request user encoder dataSource cancellationToken)
         )
         .Produces<SubmitAttemptResponse>(StatusCodes.Status201Created)
         .Produces<SubmitAttemptResponse>(StatusCodes.Status200OK)

--- a/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
+++ b/Wordfolio.Api/Wordfolio.Api/Api/Exercises/Handlers.fs
@@ -45,6 +45,9 @@ let private toSubmitAttemptErrorResponse(error: SubmitAttemptError) : IResult =
     | SubmitAttemptError.ConflictingAttempt -> Results.Conflict({| error = "A conflicting attempt already exists" |})
     | SubmitAttemptError.EvaluateError _ -> Results.StatusCode(StatusCodes.Status500InternalServerError)
 
+let private invalidRequestBody() : IResult =
+    Results.BadRequest({| error = "Invalid request body" |})
+
 let private createSessionHandler
     (request: CreateSessionRequest)
     (user: ClaimsPrincipal)
@@ -55,48 +58,48 @@ let private createSessionHandler
     match getUserId user with
     | None -> Task.FromResult(Results.Unauthorized())
     | Some userId ->
-        if
-            isNull(box request)
-            || isNull(box request.Selector)
-        then
-            Task.FromResult(Results.BadRequest({| error = "Invalid request body" |}))
-        else
-            match tryMapSelector encoder request.Selector with
-            | Error message -> Task.FromResult(Results.BadRequest({| error = message |}))
-            | Ok selector ->
-                let limitError =
-                    match selector with
-                    | ExplicitEntries entries when entries.Length > Limits.MaxSessionEntries ->
-                        Some $"Cannot specify more than {Limits.MaxSessionEntries} entries"
-                    | WorstKnown(_, count) when count <= 0 -> Some "Count must be positive"
-                    | WorstKnown(_, count) when count > Limits.MaxSessionEntries ->
-                        Some $"Count cannot exceed {Limits.MaxSessionEntries}"
-                    | _ -> None
+        match request |> Option.ofObj with
+        | None -> Task.FromResult(invalidRequestBody())
+        | Some request ->
+            match request.Selector |> Option.ofObj with
+            | None -> Task.FromResult(invalidRequestBody())
+            | Some selectorRequest ->
+                match tryMapSelector encoder selectorRequest with
+                | Error message -> Task.FromResult(Results.BadRequest({| error = message |}))
+                | Ok selector ->
+                    let limitError =
+                        match selector with
+                        | ExplicitEntries entries when entries.Length > Limits.MaxSessionEntries ->
+                            Some $"Cannot specify more than {Limits.MaxSessionEntries} entries"
+                        | WorstKnown(_, count) when count <= 0 -> Some "Count must be positive"
+                        | WorstKnown(_, count) when count > Limits.MaxSessionEntries ->
+                            Some $"Count cannot exceed {Limits.MaxSessionEntries}"
+                        | _ -> None
 
-                match limitError with
-                | Some message -> Task.FromResult(Results.BadRequest({| error = message |}))
-                | None ->
-                    let parameters: CreateSessionParameters =
-                        { UserId = UserId userId
-                          ExerciseType = toExerciseTypeDomain request.ExerciseType
-                          Selector = selector
-                          CreatedAt = DateTimeOffset.UtcNow }
+                    match limitError with
+                    | Some message -> Task.FromResult(Results.BadRequest({| error = message |}))
+                    | None ->
+                        let parameters: CreateSessionParameters =
+                            { UserId = UserId userId
+                              ExerciseType = toExerciseTypeDomain request.ExerciseType
+                              Selector = selector
+                              CreatedAt = DateTimeOffset.UtcNow }
 
-                    let env =
-                        TransactionalEnv(dataSource, cancellationToken)
+                        let env =
+                            TransactionalEnv(dataSource, cancellationToken)
 
-                    task {
-                        let! result = runInTransaction env (fun appEnv -> createSession appEnv parameters)
+                        task {
+                            let! result = runInTransaction env (fun appEnv -> createSession appEnv parameters)
 
-                        return
-                            match result with
-                            | Ok bundle ->
-                                let response =
-                                    toSessionBundleResponse encoder bundle
+                            return
+                                match result with
+                                | Ok bundle ->
+                                    let response =
+                                        toSessionBundleResponse encoder bundle
 
-                                Results.Created(ExerciseUrls.sessionById response.SessionId, response)
-                            | Error error -> toCreateSessionErrorResponse error
-                    }
+                                    Results.Created(ExerciseUrls.sessionById response.SessionId, response)
+                                | Error error -> toCreateSessionErrorResponse error
+                        }
 
 let mapExercisesEndpoints(group: RouteGroupBuilder) =
     group
@@ -155,41 +158,40 @@ let mapExercisesEndpoints(group: RouteGroupBuilder) =
                             | None, _
                             | _, None -> return Results.NotFound()
                             | Some decodedSessionId, Some decodedEntryId ->
-                                if
-                                    isNull(box request)
-                                    || isNull request.RawAnswer
-                                then
-                                    return Results.BadRequest({| error = "Invalid request body" |})
-                                else
+                                match request |> Option.ofObj with
+                                | None -> return invalidRequestBody()
+                                | Some request ->
+                                    match request.RawAnswer |> Option.ofObj with
+                                    | None -> return invalidRequestBody()
+                                    | Some rawAnswer ->
+                                        let env =
+                                            TransactionalEnv(dataSource, cancellationToken)
 
-                                    let env =
-                                        TransactionalEnv(dataSource, cancellationToken)
+                                        let! result =
+                                            runInTransaction env (fun appEnv ->
+                                                submitAttempt
+                                                    appEnv
+                                                    (UserId userId)
+                                                    (ExerciseSessionId decodedSessionId)
+                                                    (EntryId decodedEntryId)
+                                                    (RawAnswer rawAnswer)
+                                                    DateTimeOffset.UtcNow)
 
-                                    let! result =
-                                        runInTransaction env (fun appEnv ->
-                                            submitAttempt
-                                                appEnv
-                                                (UserId userId)
-                                                (ExerciseSessionId decodedSessionId)
-                                                (EntryId decodedEntryId)
-                                                (RawAnswer request.RawAnswer)
-                                                DateTimeOffset.UtcNow)
+                                        return
+                                            match result with
+                                            | Ok(Inserted inserted) ->
+                                                let response: SubmitAttemptResponse =
+                                                    { IsCorrect = inserted.IsCorrect }
 
-                                    return
-                                        match result with
-                                        | Ok(Inserted inserted) ->
-                                            let response: SubmitAttemptResponse =
-                                                { IsCorrect = inserted.IsCorrect }
+                                                Results.Created(ExerciseUrls.sessionById sessionId, response)
+                                            | Ok(IdempotentReplay replay) ->
+                                                let response: SubmitAttemptResponse =
+                                                    { IsCorrect = replay.IsCorrect }
 
-                                            Results.Created(ExerciseUrls.sessionById sessionId, response)
-                                        | Ok(IdempotentReplay replay) ->
-                                            let response: SubmitAttemptResponse =
-                                                { IsCorrect = replay.IsCorrect }
-
-                                            Results.Ok(response)
-                                        | Ok ConflictingReplay ->
-                                            toSubmitAttemptErrorResponse SubmitAttemptError.ConflictingAttempt
-                                        | Error error -> toSubmitAttemptErrorResponse error
+                                                Results.Ok(response)
+                                            | Ok ConflictingReplay ->
+                                                toSubmitAttemptErrorResponse SubmitAttemptError.ConflictingAttempt
+                                            | Error error -> toSubmitAttemptErrorResponse error
                     })
         )
         .Produces<SubmitAttemptResponse>(StatusCodes.Status201Created)


### PR DESCRIPTION
## Summary
- replace exercise prompt parsing null boxing checks with Option.ofObj-based handling
- replace exercise request validation null boxing checks with option-based request/body validation
- preserve existing bad-request and malformed-prompt behavior while leaving framework interop null checks untouched

## Testing
- dotnet fantomas .
- dotnet build --nologo
- dotnet test --nologo